### PR TITLE
remove reference to cockpit-git package for arch

### DIFF
--- a/running.html
+++ b/running.html
@@ -77,7 +77,7 @@
           <div class="col-md-12 os-info os-info-archlinux" style="display: none;">
             <div class="os-infobox">
             Cockpit can be found in the <a href="https://wiki.archlinux.org/index.php/Arch_User_Repository">Arch User Repository</a> as package
-            <a href="https://aur.archlinux.org/packages/cockpit/">cockpit</a> or <a href="https://aur.archlinux.org/packages/cockpit-git/">cockpit-git</a>.
+            <a href="https://aur.archlinux.org/packages/cockpit/">cockpit</a>.
             </div>
           </div>
           <div class="col-md-12 os-info os-info-fedoraatomic" style="display: none;">


### PR DESCRIPTION
as it's a old version, while the other is up to date