### PR TITLE
Fix the documentation for centos atomic host

### DIFF
--- a/running.html
+++ b/running.html
@@ -90,7 +90,8 @@
           </div>
           <div class="col-md-12 os-info os-info-centosatomic" style="display: none;">
             <div class="os-infobox">
-            Cockpit comes installed by default in CentOS Atomic.
+            Connect to a Centos Atomic host from an existing host running Cockpit with the Add Server UI.<br/>
+            Alternatively you can install Cockpit on the Atomic host using the command <code>sudo atomic run cockpit/ws</code>
             </div>
           </div>
           <div class="col-md-12 os-info os-info-rhel" style="display: none;">


### PR DESCRIPTION
While preparing a demo for devconf, we found that Centos Atomic got updated and do the same as Fedora.