### PR TITLE
Debian Jessie has no systemctl enable --now option

### DIFF
--- a/running.html
+++ b/running.html
@@ -172,7 +172,8 @@ sudo firewall-cmd --reload</pre>
                 <li>Install cockpit:
                   <pre>sudo apt-get install cockpit</pre></li>
                 <li>Start and enable cockpit:
-                        <pre>sudo systemctl enable --now cockpit.socket</pre>
+<pre>sudo systemctl enable cockpit.socket
+sudo systemctl start cockpit.socket</pre>
                 </li>
               </ol>
             </div>


### PR DESCRIPTION
systemctl: unrecognized option '--now'