### PR TITLE
Replace yum to dnf for Fedora

### DIFF
--- a/running.html
+++ b/running.html
@@ -84,7 +84,7 @@
 	      <p>To install Cockpit on other variants of Fedora use the following commands. For the latest versions <a href="https://copr.fedoraproject.org/coprs/g/cockpit/cockpit-preview/">use COPR</a>.</p>
               <ol>
                 <li>Install cockpit:
-                        <pre>sudo yum install cockpit</pre>
+                        <pre>sudo dnf install cockpit</pre>
                 </li>
                 <li>Enable cockpit:
                         <pre>sudo systemctl enable --now cockpit.socket</pre>


### PR DESCRIPTION
Fedora use dnf as default package manager. So I changed yum command with dnf.