### PR TITLE
apply gutter width to guide pages as well

### DIFF
--- a/assets/site.sass
+++ b/assets/site.sass
@@ -111,6 +111,8 @@ $content-width: 65rem
 
 $headline-font: 'Roboto Slab', 'Helvetica Neue', Helvetica, Arial, Liberation Sans, sans-serif
 
+$gutter-width: calc((100vw - 65rem) / 2)
+
 h1, h2, h3, h4, h5, h6
   font-family: $headline-font
 
@@ -156,7 +158,6 @@ header.masthead
     display: none !important
 
   @media screen and (min-width: $on-laptop)
-    $gutter-width: calc((100vw - 65rem) / 2)
     padding: 0 $gutter-width
     align-items: space-between
 
@@ -486,6 +487,11 @@ html.cockpit-guide
     margin-bottom: 0
 
   table.navigation
+
+    @media screen and (min-width: $on-laptop)
+      padding-left: $gutter-width
+      padding-right: $gutter-width
+
     th
       text-align: center !important
       padding: 0.5rem


### PR DESCRIPTION
This makes the content of the guide header fit into the maximum width of the page.