### PR TITLE
External documentation

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -8,7 +8,7 @@
   url: /running.html
 
 - title: Contribute
-  url: https://github.com/cockpit-project/cockpit/wiki/Contributing
+  url: /external/wiki/Contributing.html
 
 - title: Documentation
   url: /guide/latest/

--- a/_scripts/update-external-docs.rb
+++ b/_scripts/update-external-docs.rb
@@ -1,0 +1,110 @@
+#!/usr/bin/ruby
+
+### Editable variables ###
+
+# Pages to fetch from the Cockpit wiki
+wiki_pages = [
+  "Cockpit-Coding-Guidelines",
+  "Contributing",
+  "Workflow",
+]
+
+# Pages to fetch from the Cockpit git repo
+source_pages = [
+  "HACKING.md",
+  "test/README",
+]
+
+# URLs to rewrite
+@url_rewrites = {
+  "https://github.com/cockpit-project/cockpit/blob/master/HACKING.md" =>
+  "{{ site.baseurl }}/external/source/HACKING.html",
+
+  "https://github.com/cockpit-project/cockpit/blob/master/test/README" =>
+  "{{ site.baseurl }}/external/source/test/README.html",
+
+  "About#project-ideals" =>
+  "{{ site.baseurl }}/ideals.html",
+
+  "About#contact-developers--stay-up-to-date" =>
+  "https://github.com/cockpit-project/cockpit/wiki/About",
+
+  "http://files.cockpit-project.org/guide/latest/" =>
+  "{{ site.baseurl }}/guide/latest/",
+
+  "Ideas" =>
+  "https://github.com/cockpit-project/cockpit/wiki/Ideas",
+
+  "https://github.com/cockpit-project/cockpit/wiki/Workflow#review-criteria" =>
+  "/external/wiki/Workflow#review-criteria",
+
+  "How-@mvollmer-merges-pull-requests" =>
+  "https://github.com/cockpit-project/cockpit/wiki/How-@mvollmer-merges-pull-requests",
+
+  "Design" =>
+  "https://github.com/cockpit-project/cockpit/wiki/Design",
+}
+
+### Code below ###
+
+require 'bundler'
+require 'open-uri'
+require 'yaml'
+require 'fileutils'
+
+@prefix = {
+  source: 'https://github.com/cockpit-project/cockpit/blob/master/',
+  source_raw: 'https://raw.githubusercontent.com/cockpit-project/cockpit/master/',
+  wiki: 'https://github.com/cockpit-project/cockpit/wiki/',
+  wiki_raw: 'https://raw.githubusercontent.com/wiki/cockpit-project/cockpit/',
+  issues: 'https://github.com/cockpit-project/cockpit/issues',
+}
+
+@external_dir = File.expand_path "#{__dir__}/../external/"
+
+def fetch_and_add(pages, type=:source)
+  pages.each do |page|
+    suffix = (type == :wiki) ? '.md' : ''
+    url = @prefix[type] + page
+    url_raw = @prefix["#{type}_raw".to_sym] + page + suffix
+    file = "#{type}/#{page}"
+    file += ".md" unless page.match(/\.md$/)
+
+    doc = open(url_raw).read
+
+    if (type == :source)
+      # Extract the title for git source, as filenames are often "README"
+      title = doc.match(/^#[^\n]*\n/m)[0].gsub(/#/, '').strip
+
+      # Strip the title, as it's added in our Jekyll codebase
+      doc = doc.sub(/^#* #{title}/m, '')
+    else
+      # Show the path as title for wiki pages,
+      # as wiki pages need to have relevant names
+      title = page.gsub('/', ' / ').gsub('-', ' ').sub(/\.md$/i, '')
+
+      # Indent pages 1 level if there's a matching H1 already
+      # (similar to what GitHub does on wiki pages)
+      doc = doc.gsub(/^#/m, '##') if doc.match(/^# /m)
+    end
+
+    # Rewrite URLs
+    @url_rewrites.each do |before, after|
+      doc = doc.gsub("](#{before})", "](#{after})")
+    end
+
+    # Fix issue link URLs
+    doc = doc.gsub(/\]\(..\/issues/m, "](#{@prefix[:issues]}")
+
+    frontmatter = {
+      'title' => title,
+      'source' => url
+    }.to_yaml
+
+    FileUtils.mkdir_p "#{@external_dir}/#{File.dirname file}"
+    File.write "#{@external_dir}/#{file}", frontmatter + "---\n\n" + doc
+  end
+end
+
+fetch_and_add(wiki_pages, :wiki)
+fetch_and_add(source_pages, :source)

--- a/external/source/HACKING.md
+++ b/external/source/HACKING.md
@@ -1,0 +1,305 @@
+---
+title: Hacking on Cockpit
+source: https://github.com/cockpit-project/cockpit/blob/master/HACKING.md
+---
+
+
+
+Here's where to get the code:
+
+    $ git clone https://github.com/cockpit-project/cockpit
+    $ cd cockpit/
+
+The remainder of the commands assume you're in the top level of the
+Cockpit git repository checkout.
+
+## Getting the development dependencies
+
+Cockpit uses Node.js during development. Node.js is not used at runtime.
+To make changes on Cockpit you'll want to install Node.js, NPM and
+various development dependencies like Webpack.
+
+On Debian or Ubuntu:
+
+    $ sudo apt-get install nodejs npm
+
+On Fedora:
+
+    $ sudo yum install nodejs npm
+
+And lastly get Webpack and the development dependencies:
+
+    $ sudo npm install -g webpack
+    $ npm install
+
+When relying on CI to run the test suite, this is all that is
+necessary to work on the JavaScript components of Cockpit.
+
+To actually build the Cockpit binaries themselves from source
+(including to run the integration tests locally), you will need
+additional header files and other components. Check
+`tools/cockpit.spec` for the concrete Fedora build dependencies.
+The following should work in a fresh Git clone:
+
+    $ sudo yum install yum-utils
+    $ sudo yum-builddep tools/cockpit.spec
+
+In addition, for testing, the following dependencies are required:
+
+    $ sudo yum install curl expect \
+        libvirt libvirt-client libvirt-daemon libvirt-python \
+        python python-libguestfs python-lxml libguestfs-xfs \
+        libguestfs-tools qemu qemu-kvm rpm-build rsync xz
+
+## Running the integration test suite
+
+Refer to the [testing README](test/README) for details on running
+the Cockpit integration tests locally.
+
+## Working on Cockpit using Vagrant
+
+It is recommended to use a Vagrant virtual machine to develop Cockpit.
+
+Most of Cockpit is written in javascript. Almost all of this code is found
+in the packages in the pkg/ subdirectory of the Cockpit git checkout.
+
+To use Vagrant to develop Cockpit, run in its top level git checkout.
+In some cases you may need to use `sudo` with vagrant commands:
+
+    $ vagrant up
+
+Now you can edit files in the `pkg/` subdirectory of the Cockpit sources.
+Use the `webpack` command to build those sources. The changes should
+take effect after syncing them to the Vagrant VM. For example:
+
+    $ webpack
+    $ vagrant rsync
+
+Now log into Cockpit on the vagrant VM to see your changes. Use the
+user name 'admin' and the password 'foobar' to log in. The Cockpit
+instance in vagrant should be available at the following URL:
+
+http://localhost:9090
+
+If you want to setup automatic syncing as you edit javascript files
+you can:
+
+    $ vagrant rsync-auto &
+    $ webpack --progress --colors --watch
+
+## Working on your local machine
+
+It's easy to set up your local Linux machine for rapid development of Cockpit's
+javascript code. First install Cockpit on your local machine as described in:
+
+http://cockpit-project.org/running.html
+
+Next run this command from your top level Cockpit checkout directory, and make
+sure to run it as the same user that you'll use to log into Cockpit below.
+
+    $ mkdir -p ~/.local/share/
+    $ ln -s $(pwd)/dist ~/.local/share/cockpit
+
+This will cause cockpit to read javascript and HTML files directly from the built
+package output directory instead of using the installed Cockpit UI files.
+
+Next run Webpack to build the javascript code:
+
+    $ webpack
+
+Now you can log into Cockpit on your local Linux machine at the following address.
+Use the same user and password that you used to log into your Linux desktop.
+
+http://localhost:9090
+
+If you want to setup automatic syncing as you edit javascript files you can:
+
+    $ webpack --progress --colors --watch
+
+To make Cockpit again use the installed code, rather than that from your
+git checkout directory, run the following, and log into Cockpit again:
+
+    $ rm ~/.local/share/cockpit
+
+## Contributing a change
+
+Make a pull request on github.com with your change. All changes get
+reviewed, tested and iterated on before getting into Cockpit. The general
+workflow is described in the [wiki](https://github.com/cockpit-project/cockpit/wiki/Workflow).
+Don't feel bad if there's multiple steps back and forth asking for changes
+or tweaks before your change gets in.
+
+You need to be familiar with git to contribute a change. Do your changes
+on a branch. Your change should be one or more git commits that each
+contain one single logical simple reviewable change, without modifications
+that are unrelated to the commit message.
+
+Cockpit is a designed project. Anything that the user will see should have
+design done first. This is done on the wiki and mailing list.
+
+Bigger changes need to be discussed on #cockpit or our mailing list
+cockpit-devel@lists.fedoraproject.org before you invest too much time and
+energy.
+
+Feature changes should have a video and/or screenshots that show the
+change. This video should be uploaded to Youtube or another service that
+allows video embedding. Use a command like this to record a video including
+the browser frame:
+
+    $ recordmydesktop -x 1 -y 200 --width 1024 --height 576 \
+        --fps 24 --freq 44100 --v_bitrate 2000000
+
+You can also resize your browser window and move it to the right location with
+a script. In Firefox you can open the Scratchpad (`Shift+F4`) and enter the
+following commands:
+
+    $ window.resizeTo(1024, 576);
+    $ window.moveTo(1, 200);
+
+Then run it with `Ctrl+R` when the browser is showing an empty tab, e.g.
+`about:newtab`. You may need to adjust the positions for your environment.
+
+## Debug logging of Cockpit processes
+
+All messages from the various cockpit processes go to the journal and can
+be seen with commands like:
+
+    $ sudo journalctl -f
+
+Much of Cockpit has more verbose internal debug logging that can be
+enabled when trying to track down a problem. To turn it on add a file
+to your system like this:
+
+    $ sudo mkdir -p /etc/systemd/system/cockpit.service.d
+    $ sudo sh -c 'printf "[Service]\nEnvironment=G_MESSAGES_DEBUG=cockpit-ws,cockpit-bridge\nUser=root\nGroup=\n" > /etc/systemd/system/cockpit.service.d/debug.conf'
+    $ sudo systemctl daemon-reload
+    $ sudo systemctl restart cockpit
+
+In the above command you'll notice the string "cockpit-ws". This is a log
+domain. There are various log domains you can enable:
+
+ * cockpit-bridge: Cockpit bridge detailed debug messages
+ * cockpit-protocol: Very verbose low level traffic logging
+ * cockpit-ws: Cockpit Web Service detailed debug messages
+ * WebSocket: Verbose low level WebSocket logging
+
+To revert the above logging changes:
+
+    $ sudo rm /etc/systemd/system/cockpit.service.d/debug.conf
+    $ sudo systemctl daemon-reload
+    $ sudo systemctl restart cockpit
+
+## Building Cockpit binaries
+
+For more complex hacking on Cockpit beyond the user interface, you need to
+build the Cockpit binaries locally and install the relevant dependencies.
+Currently, recent x86_64 architectures of Fedora are most often used for
+development.
+
+Before attempting to build anything, first make sure the relevant
+dependencies are installed as described in "Getting the development
+dependencies" above.
+
+Cockpit uses the autotools and thus there are the familiar `./configure`
+script and the familar Makefile targets.
+
+But after a fresh clone of the Cockpit sources, you need to prepare
+them by running `autogen.sh` like this:
+
+    $ mkdir build
+    $ cd build
+    $ ../autogen.sh --prefix=/usr --enable-debug
+
+As shown, `autogen.sh` runs 'configure' with the given options, and it
+also prepares the build tree by downloading various nodejs dependencies.
+
+When working with a Git clone, it is therefore best to simply always
+run `../autogen.sh` instead of `../configure`.
+
+Creating a build directory puts the output of the build in a separate
+directory, rather than mixing it in with the sources, which is confusing.
+
+Then you can build the sources and install them, as usual:
+
+    $ make
+    $ sudo make install
+    $ sudo cp ../src/bridge/cockpit.pam.insecure /etc/pam.d/cockpit
+
+This will install Cockpit and all support files, and will install a
+simplistic PAM configuration.
+
+Cockpit has a single non-recursive Makefile.  You can only run `make`
+from the top-level and it will always rebuild the whole project.
+
+If you prefer to install to a different `--prefix` and would prefer
+that `make install` not write outside that prefix, then specify the
+`--enable-prefix-only` option to `autogen.sh`. This will result in an
+installation of Cockpit that does not work without further tweaking.
+For advanced users only.
+
+You can run unit tests of the current checkout:
+
+    $ make check
+
+These should finish very quickly and it is good practice to do it
+often.
+
+For debugging individual tests, there are compiled binaries in the
+build directory. For QUnit tests (javascript), you can run
+
+    $ ./test-server
+
+which will output a URL to connect to with a browser, such as
+`http://localhost:8765/dist/base1/test-dbus.html`. Adjust the path
+for different tests and inspect the results there.
+
+To run the integration tests, see `test/README`.
+
+## Running Cockpit processes under a debugger
+
+You may want to run cockpit-ws under a debugger such as valgrind or gdb.
+You can run these processes as your own user, although you won't be able
+to debug all the authentication logic in those cases.
+
+First of all make sure Cockpit is installed correctly. Even though we
+will be running cockpit-ws from the built sources this still relies on
+some of the right bits being installed in order for Cockpit to work
+(ie: PAM stack, UI files, cockpit-bridge, etc.)
+
+This is how you would run cockpit-ws under gdb:
+
+    $ export G_DEBUG=fatal-criticals
+    $ export G_MESSAGES_DEBUG=cockpit-ws,cockpit-wrapper,cockpit-bridge
+    $ gdb --args ./cockpit-ws --port 10000 --no-tls
+
+And you can run cockpit-ws and cockpit-bridge under valgrind like this:
+
+    $ export G_DEBUG=fatal-criticals
+    $ export G_MESSAGES_DEBUG=cockpit-ws,cockpit-wrapper,cockpit-bridge
+    $ valgrind --trace-children=yes --trace-children-skip='*unix_chkpwd*' \
+          ./cockpit-ws --port 10000 --no-tls
+
+Note that cockpit-session and cockpit-bridge will run from the installed
+prefix, rather than your build tree.
+
+# Running Internet Explorer to test Cockpit
+
+While running Firefox or Chrome on your Linux or Mac development machine
+may be easy, some people find it harder to test Internet Explorer. To
+use the following method you need access to the ```windows-8``` testing
+image. This image cannot be freely distributed for licensing reasons.
+
+Make sure you have the ```virt-viewer``` package installed on your Linux
+machine. And then run the following from the Cockpit checkout directory:
+
+    $ test/vm-run --network windows-8
+
+If the image is not yet downloaded, it'll take a while to download and
+you'll see progress on the command line. A screen will pop up and
+Windows will boot. Various command lines will show up once Windows has
+started. Ignore or minimize them, before starting Internet Explorer.
+
+Type the following into Internet Explorer's address bar to access Cockpit
+running on your development machine:
+
+     https://10.111.112.1:9090

--- a/external/source/test/README.md
+++ b/external/source/test/README.md
@@ -1,0 +1,215 @@
+---
+title: Integration Tests of Cockpit
+source: https://github.com/cockpit-project/cockpit/blob/master/test/README
+---
+
+
+
+This directory contains automated integration tests for Cockpit, and the support
+files for them.
+
+To run the tests on Fedora, refer to the [HACKING](../HACKING.md) guide for
+installation of all of the necessary build and test dependencies. There's
+no need to trigger a build manually - the test suite preparation step below
+will handle that.
+
+If test failures are encountered that look like they may be related to problems
+with nested virtualization, refer to
+[this Fedora guide](https://fedoraproject.org/wiki/How_to_enable_nested_virtualization_in_KVM)
+for more details and recommendations on ensuring it is enabled correctly.
+
+## Introduction
+
+Before running the tests, ensure Cockpit has been built where the test suite
+expects to find it (do NOT run the build step as root):
+
+   $ ./bots/image-prepare
+
+To run the integration tests run the following (do NOT run the integration tests
+as root):
+
+    $ ./test/verify/run-tests
+
+The tests will automatically download the VM images they need, so expect
+that the initial run may take a couple of hours (there are quite a few
+images to retrieve for different scenario tests).
+
+Alternatively you can run an individual test like this:
+
+    $ ./bots/image-prepare
+    $ ./test/verify/check-session
+
+To see more verbose output from the test, use the --verbose and/or --trace flags:
+
+    $ ./test/verify/check-session --verbose --trace
+
+In addition if you specify `--sit`, then the test will wait on failure and allow
+you to log into cockpit and/or the test instance and diagnose the issue. An address
+will be printed of the test instance.
+
+    $ ./test/verify/check-session --trace --sit
+
+## Details
+
+The verify test suite is the main test suite:
+
+ * test/verify/run-tests: Run all tests
+ * test/verify/check-*: Run the selected tests
+
+## Test Configuration
+
+You can set these environment variables to configure the test suite:
+
+  TEST_OS    The OS to run the tests in.  Currently supported values:
+                "centos-7"
+                "debian-stable"
+                "debian-testing"
+                "fedora-25"
+                "fedora-26"
+                "fedora-atomic"
+                "fedora-testing"
+                "rhel-7"
+                "ubuntu-1604"
+             "fedora-26" is the default (testvm.py)
+
+  TEST_DATA  Where to find and store test machine images.  The
+             default is the same directory that this README file is in.
+
+  TEST_JOBS  How many tests to run in parallel.  The default is 1.
+
+## Test machines and their images
+
+The code under test is executed in one or more dedicated virtual
+machines, called the "test machines".  Fresh test machines are started
+for each test. To pull all the needed images for a given commit, use:
+
+ $ bots/image-download
+
+A test machine runs a "test machine image".  Such a test machine image
+contains the root filesystem that is booted inside the virtual
+machine.  A running test machine can write to its root filesystem, of
+course, but these changes are (usually) not propagated back to its
+image.  Thus, you can run multiple test machines from the same image,
+at the same time or one after the other, and each test machine starts
+with a clean state.
+
+A test machine image is created with image-create, like so:
+
+  $ bots/image-create -v fedora-atomic
+
+The image will be created in $TEST_DATA/images/. In addition a link
+reference will be created in bots/images/.
+
+If you wish that others use this new image then you should commit the
+new reference link, and use `image-upload` to upload the new image. You
+would need to have Cockpit commit access to do this:
+
+  $ bots/image-upload fedora-atomic
+
+There is more than one test machine image. For example, you might
+want to test a scenario where Cockpit on one machine talks to FreeIPA
+on another, and you want those two machines to use different images.
+
+This is handled by passing a specific image to image-create
+and other scripts that work with test machine images.
+
+  "fedora-NN" -- The basic image for running the development version of Cockpit.
+                 This is the default.
+
+  "fedora-stock" -- A stock installation of Fedora, including the stock
+                    version of Cockpit.  This is used to test compatibility
+                    between released versions of Cockpit and the development version.
+
+  "ipa"       -- A FreeIPA server.
+
+  "openshift" -- An Openshift Origin server.
+
+A test machine image created by image-create doesn't contain any Cockpit
+code in it yet.  You can build and install the currently checked out
+working copy of Cockpit like this:
+
+  $ bots/image-prepare fedora-25
+
+This either needs a configured/built tree (build in mock or a development VM)
+or cockpit's build dependencies installed.
+
+image-prepare will prepare a test machine image used for the next test run,
+but will not modify the saved version in $TEST_DATA/images.  Use
+vm-reset to revert the test machine images for the next run to the
+versions in $TEST_DATA/images.
+
+A typical sequence of steps would thus be the following:
+
+  $ bots/image-download
+  $ test/vm-reset            # Start over
+  $ tools/make-rpms          # Create rpms
+  $ bots/image-install ...   # Install code to test
+  $ test/verify/check-...    # Run some tests
+
+  $ test/vm-reset            # Start over
+  $ bots/image-prepare ...   # Install code to test
+  $ bots/verify/check-...    # Run some tests
+
+You can perform all of the above easily by doing `./testsuite-prepare`
+
+## Running tests
+
+Once you have a test machine image that contains the version of
+Cockpit that you want to test, you can run tests by picking a program
+and just executing it:
+
+  $ test/verify/check-connection
+
+Many of the verify tests can also be run against an already running
+machine. Although be aware that lots of the tests change state on
+the target machine.
+
+  $ test/verify/check-connection --machine=10.1.1.2
+
+The test/containers/ tests use the same VMs as the above test/verify/ ones.
+But they don't have a separate "prepare" step/script; instead, the first time
+you run test/containers/run-tests you need to use the "-i" option to
+build/install cockpit into the test VM. This needs to be done with a compatible
+TEST_OS (usually a recent "fedora-*").
+
+## Debugging tests
+
+If you pass the "-s" ("sit on failure") option to a test program, it
+will pause when a failure occurs so that you can log into the test
+machine and investigate the problem.
+
+A test will print out the commands to access it when it fails in this
+way. You can log into a running test-machine using ssh. If you add
+a snippet like this to your ~/.ssh/config then you'll be able to
+log in without authentication:
+
+    Host 127.0.0.2
+        User root
+        StrictHostKeyChecking no
+        UserKnownHostsFile /dev/null
+        IdentityFile ~/src/cockpit/test/common/identity
+
+You can also put calls to sit() into the tests themselves to stop them
+at strategic places.
+
+That way, you can run a test cleanly while still being able to make
+quick changes, such as adding debugging output to JavaScript.
+
+## Guidelines for writing tests
+
+It is OK for a test to destroy the test machine OS installation, or
+otherwise modify it without cleaning up.  For example, it is OK to
+remove all of /etc just to see what happens.  The next test will get a
+pristine test machine.
+
+A fast running test suite is more important than independent,
+small test cases.
+
+Thus, it is OK for tests to be long.  Starting the test machine is so
+slow that we should run as many checks within a single session as make
+sense.
+
+Still, within a long test, try to have independent sections, where
+each section returns the machine to more or less the state that it was
+in before the section.  This makes it easier to run these sections
+ad-hoc when doing incremental development.

--- a/external/wiki/Cockpit-Coding-Guidelines.md
+++ b/external/wiki/Cockpit-Coding-Guidelines.md
@@ -1,0 +1,225 @@
+---
+title: Cockpit Coding Guidelines
+source: https://github.com/cockpit-project/cockpit/wiki/Cockpit-Coding-Guidelines
+---
+
+## General
+* No trailing whitespace, no tab characters, except in Makefile.am files
+* Generally line length should be limited to 120 chars
+* Indentation: 4 spaces per level, no tabs
+
+## Languages
+* [C](#cstyle)
+* [JavaScript](#jsstyle)
+* [CSS/HTML](#cssstyle)
+* [Python](#pythonstyle) (only for testing, not a runtime or build dependency of Cockpit)
+
+<a name="cstyle"/>
+
+## C style
+
+* [Gtk+ coding standards](https://github.com/GNOME/gtk/blob/master/docs/CODING-STYLE)
+* C99 is allowed and the default.
+* When in doubt, check the surrounding code and try to imitate it.
+
+* Exception: We don't require tabular alignment of function arguments like GTK and Glib do. Function definitions look like this:
+
+```c
+static JsonArray *
+interframe_compress_samples (int count,
+                             JsonArray *samples)
+{
+  /* code */
+}
+```
+
+[Sample code](https://github.com/cockpit-project/cockpit/blob/30270ca580159cc4a0e0238b17f75bc7e03cbe2f/src/websocket/websocketconnection.c#L658-L671)
+```c
+/* Store the code/data payload */
+if (len >= 2)
+  {
+    pv->peer_close_code = (guint16)data[0] << 8 | data[1];
+  }
+if (len > 2)
+  {
+    data += 2;
+    len -= 2;
+    if (g_utf8_validate ((gchar *)data, len, NULL))
+      pv->peer_close_data = g_strndup ((gchar *)data, len);
+    else
+      g_message ("received non-UTF8 close data: %d '%.*s' %d", (int)len, (int)len, (gchar *)data, (int)data[0]);
+  }
+```
+
+<a name="jsstyle"/>
+
+## JavaScript style
+
+* Private scopes are only necessary in code that is not bundled with webpack.
+* ```"use strict"``` should be set on code that is not bundled with webpack.
+* [Crockford](http://javascript.crockford.com/code.html) with lots of exceptions
+* Chained calls may be placed on separate lines for readability (see example below)
+
+Don't indent top level code, even if using a top level private scope (see above).
+
+```javascript
+(function() {
+"use strict";
+
+console.log("not indented");
+
+}());
+```
+
+Variables should be declared outside of loops or condition braces.
+
+```javascript
+{
+  var demo = 1; /* here */
+  while(false) {
+     /* not here */
+  }
+}
+```
+
+Function declarations and invocations should have no space after function name. Function starting brace goes on same line as ```function``` keyword.
+
+```javascript
+function name(arg) {
+   /* body */
+}
+```
+
+Anonymous functions do not need a space between the ```function``` keyword and arguments.
+
+```javascript
+div.onclick = function(e) {
+   /* body */
+}
+```
+
+Control flow keywords such as ```if``` ```for``` and ```while``` should have a space after them. If there is only one statement in a conditional or loop, you may leave out the braces.
+
+```javascript
+while (false)
+   console.log("never reached");
+```
+
+All binary operators except . (period) and ( (left parenthesis) and [ (left bracket) should be separated from their operands by a space.
+
+[More Sample code](https://github.com/cockpit-project/cockpit/blob/30270ca580159cc4a0e0238b17f75bc7e03cbe2f/pkg/shell/cockpit-docker.js#L588-L597)
+```javascript
+/* if an image is older than two days, don't show the time */
+var threshold_date = new Date(image.Created * 1000);
+threshold_date.setDate(threshold_date.getDate() + 2);
+
+if (threshold_date > (new Date())) {
+    $(row[1]).text(new Date(image.Created * 1000).toLocaleString());
+} else {
+    var creation_date = new Date(image.Created * 1000);
+
+    /* we hide the time, so put full timestamp in the hover text */
+    $(row[1])
+        .text(creation_date.toLocaleDateString())
+        .attr("title", creation_date.toLocaleString());
+}
+```
+
+New javascript files should be in the [Asyncronous Module Definition](http://dojotoolkit.org/documentation/tutorials/1.10/modules/index.html) form. For example:
+
+```javascript
+define([
+    "jquery",
+    "base1/cockpit"
+], function($, cockpit) {
+    /* ... */
+
+    var module = {
+        api1: function api1() { /* ... */ },
+        api2: function api2() { /* ... */ }
+    };
+
+    return module;
+});
+```
+
+As a general rule: Modules that return API (as above) should avoid global side-effects. And modules that have global side-effects should not return or define API.
+
+React/JSX conventions:
+* Wrap multiline jsx in parentheses
+* Inside JSX code, simple variables or expressions don't require spaces in curly braces, complex ones do, `{key.val}` and `{key}` but `{ this.props.fun_stuff.map(myMapFunction) }`
+
+```jsx
+var panel = (
+    <tr className="listing-panel">
+        <td colSpan={ header_entries.length + (expand_toggle?1:0) }>
+            <div className="listing-head">
+                <div className="listing-actions">
+                    {this.props.listingActions}
+                </div>
+                <ul className="nav nav-tabs nav-tabs-pf">
+                    {links}
+                </ul>
+            </div>
+            {tabs}
+        </td>
+    </tr>
+);
+```
+
+
+
+<a name="cssstyle"/>
+
+## CSS/HTML style
+* Use dashes instead of underscores in ids
+* Use namespaces for ids if writing code that is consumed as part of a larger whole.
+
+[Sample code](https://github.com/cockpit-project/cockpit/blob/30270ca580159cc4a0e0238b17f75bc7e03cbe2f/pkg/base/cockpit.css#L37-L45)
+```css
+/* Panels don't draw borders between them */
+.panel > .table > tbody:first-child td {
+    border-top: 1px solid rgb(221, 221, 221);
+}
+
+/* Table headers should not generate a double border */
+.panel .table thead tr th {
+    border-bottom: none;
+}
+```
+
+<a name="pythonstyle"/>
+
+## Python style
+* [PEP 8](https://www.python.org/dev/peps/pep-0008/)
+
+[Sample code](https://github.com/cockpit-project/cockpit/blob/badd626498dd469dae10ff13f8ad03717835ccb7/tools/tap-gtester#L97-L112)
+```python
+def run(self, proc, output=""):
+    # Complete retrieval of the list of tests
+    output += proc.stdout.read()
+    proc.wait()
+    if proc.returncode:
+        sys.stderr.write("tap-gtester: listing GTest tests failed: %d\n" % proc.returncode)
+        return proc.returncode
+    self.test_remaining = []
+    for line in output.split("\n"):
+        if line.startswith("/"):
+            self.test_remaining.append(line.strip())
+    if not self.test_remaining:
+        print "Bail out! No tests found in GTest: %s" % self.command[0]
+        return 0
+
+    print "1..%d" % len(self.test_remaining)
+```
+
+<a name="emacs"/>
+
+## Emacs setup
+```emacs
+(setq indent-tabs-mode nil)
+(add-hook 'before-save-hook 'delete-trailing-whitespace)
+(setq whitespace-style '(face trailing lines-tail empty))
+(setq whitespace-line-column 120)
+(global-whitespace-mode)
+```

--- a/external/wiki/Contributing.md
+++ b/external/wiki/Contributing.md
@@ -1,0 +1,34 @@
+---
+title: Contributing
+source: https://github.com/cockpit-project/cockpit/wiki/Contributing
+---
+
+### General
+Cockpit is a meritocracy: prove you are reliable and you'll earn commit privileges.
+
+Work currently in progress and bugs are in the [issue tracker](https://github.com/cockpit-project/cockpit/issues). There is no separate bug tracker, so use this liberally for bugs, feature requests and proposed changes. Modify the project in your own fork and issue a pull request once you want other developers to take a look at what you have done and discuss the proposed changes.
+
+In order to avoid duplicate work, it is advisable to show others what you are working on. You can do this on [irc, the mailing list and trello](https://github.com/cockpit-project/cockpit/wiki/About) or by discussing issues in their respective github thread. If an issue has a developer assigned, you may wish to check with that developer to see if they are already working on the issue.
+
+### Getting Started
+ * Guide: [Set up a system and start hacking]({{ site.baseurl }}/external/source/HACKING.html)
+ * Guide: [Set up integration tests]({{ site.baseurl }}/external/source/test/README.html). Automated tests are an important part of Cockpit and every new feature should be accompanied by its tests.
+ * Keep in mind the [project ideals]({{ site.baseurl }}/ideals.html)
+ * If you are looking for someplace to start developing, issues are marked [with a starter label](https://github.com/cockpit-project/cockpit/issues?q=is%3Aopen+is%3Aissue+label%3Astarter) when they are a good introduction to Cockpit and of limited scope.
+ * For broader inspiration and ideas you may want to look at the [Ideas page](https://github.com/cockpit-project/cockpit/wiki/Ideas).
+ * [Documentation]({{ site.baseurl }}/guide/latest/) (be aware: possible version differences)
+
+### Source Code
+Cockpit encompasses different languages and is developed by multiple developers. When contributing, please adhere to the [coding style guidelines](Cockpit-Coding-Guidelines).
+
+Here is a detailed description of the [commit workflow](Workflow) (including [review criteria](/external/wiki/Workflow#review-criteria)) and as an example, [how @mvollmer merges pull requests](https://github.com/cockpit-project/cockpit/wiki/How-@mvollmer-merges-pull-requests).
+
+### User Interface / Design
+Cockpit's user interface is based on [PatternFly](https://www.patternfly.org/). Please be aware of this, especially of the [design patterns](https://www.patternfly.org/wikis/patterns/) when proposing changes to the user interface.
+
+An overview of things currently in design can be found [here](https://github.com/cockpit-project/cockpit/wiki/Design).
+
+### Further reading
+ * [Create plugins for the user interface](http://stef.thewalter.net/creating-plugins-for-the-cockpit-user-interface.html)
+ * [Use DBUS from javascript in Cockpit](http://stef.thewalter.net/using-dbus-from-javascript-in-cockpit.html)
+ * [Protocol for web access to system APIs](http://stef.thewalter.net/protocol-for-web-access-to-system-apis.html)

--- a/external/wiki/Workflow.md
+++ b/external/wiki/Workflow.md
@@ -1,0 +1,97 @@
+---
+title: Workflow
+source: https://github.com/cockpit-project/cockpit/wiki/Workflow
+---
+
+These are the rules we try to follow when working on Cockpit.
+
+## Review Criteria
+* Each commit should be easy to read.
+
+  Commits are for people to read, so try to tell the story of a new feature clearly.  For example, refactor the code in a preparatory commit to make the actual change in the next commit easier to understand.  Try to separate changes to separate pieces of the code base.
+
+  Historical accuracy of how you figured out the final form of a change is ususally not very interesting, but it doesn't need to be totally hidden of course.  If rewriting historical commits is tricky and has a high risk of introducing bugs, don't do it.
+
+* Each commit should adhere to the [Cockpit Coding Guidelines](https://github.com/cockpit-project/cockpit/wiki/Cockpit-Coding-Guidelines)
+
+* The tip of master must always pass the test suites
+
+  A fleet of robots run the test suites for each pull request.  This includes unit tests, integration tests, and browser-compatability tests.
+
+  The integration tests performed are slow and brittle, and not all failures are caused by bugs in the pull request, but don't just blame every failure on the crappy tests.
+
+* Whenever a pull request changes the API or makes other significant changes, the documentation needs to be updated. Documentation locations that require manual updating include:
+  * https://github.com/cockpit-project/cockpit/blob/master/README.md
+  * https://github.com/cockpit-project/cockpit/blob/master/HACKING.md
+  * https://github.com/cockpit-project/cockpit/blob/master/test/README
+  * the [documentation tree](https://github.com/cockpit-project/cockpit/tree/master/doc), used for [the guide]({{ site.baseurl }}/guide/latest/)
+
+## Git-related / Merging Conventions
+
+* No merge commits on master.
+
+  See https://sandofsky.com/blog/git-workflow.html for the motivation.  In brief, merge commits are confusing when rolling back history to find the commit that introduced a particular bug/feature.
+
+  Thus, we normally use "Rebase and Merge" when merging pull requests, but see below for the special "GH #nnnn" line that needs to be present for this to work.
+
+* Each commit on master should have been reviewed.  (Almost each.)
+
+  The commits made during a release to bump the version number etc don't need to be formally reviewed.
+
+  We trust that all information about the review process will be available from GitHub, thus we don't add Reviewed-By lines or similar markers to the commit messages anymore.  However, we need a strong connection between the commits and the actual pull request so that the review for every commit on master can be found.
+
+  Thus, commits should explicitly reference their pull request. The last line of the commit message should just be "#nnnn".
+
+  It is best if the author of a pull request adds the "#nnnn" line to his/her own pull requests.  This requires rewriting the PR since the number isn't known yet when creating the pull request.
+
+* The subject of a commit should start with a short `<topic>: ` prefix.
+
+  This is usually the package name for frontend code, such as `shell`, `base`, or `server-systemd`, or some other suitable directory name.  Check the existing commits for examples.
+
+* If a commit fixes an issue, it should have a `Fixes #NNN` line.
+
+  At the bottom, before the `Reviewed-by` line.
+
+* Force pushing to master is allowed, BUT...
+
+  ...write an email to `cockpit-devel@lists.fedorahosted.org` to explain what has been done and why.
+
+  Don't force push master lightly of course.  One reason would be to remove an accidental merge commit, or to quickly correct wrong or missing `Closes` or `Fixes` lines.  When in doubt, don't force push master, close/reopen issues manually as needed, and live with the shame.
+ 
+* The main cockpit-project/cockpit repository should not have any work-in-progress branches.
+
+  Otherwise, there will be a huge number of these branches over time.  We could delete them, but that throws away information, and people would still have them in their local clones.
+
+  Instead, each developer (including the core developers) should make his/her own clone and submit pull requests from there.  This makes it slightly harder to take over a pull request from another developer, but it can be done.
+
+* A pull request with a `WIP` prefix in the name is not yet ready for serious review.
+
+  You can make those pull requests to more visibly share some of your work with the rest of the team.
+
+* Github's 'Request changes' feature will be used to mark pull requests that have been reviewed and need action from the submitter.
+
+  This includes changes to the code, or just replies to comments.  Once you have done all that work, you should dismiss the review and comment to indicate that it is ready for review again.
+
+* A pull request is updated with copious rewrites and rebases until it has a small number of 'perfect' commits.
+
+  These commits should be fit for master and the pull request is merged by rebasing these commits onto master.
+
+* A pull request that depends on other pull requests declares that in its description.
+
+  When the commits of a pull request sit on top of the commits of another pull request, it's not easy to see from github where one pull request ends and the other begins.  Thus, it is import to note dependencies explicitly so that the reviewer is less likely to get confused.
+
+## Merge Workflow
+
+We usually merge requests from the GitHub Web UI with the "Rebase and Merge" button, but sometimes you might need to do it manually.  **Don't follow the instructions for manual merging given by GitHub.**  They are for the regular merge, and will produce a merge commit.
+
+This is Git, so there are many ways to arrive at the wanted result, and all are equally obscure.  Use whatever method is most familiar to you.  Here is one way:
+
+```
+$ git fetch origin master
+$ git fetch origin pull/<PR-ID>/head
+$ git rebase -i origin/master FETCH_HEAD
+$ git log
+## Check if everything looks good
+$ git push origin HEAD:master
+$ git checkout master
+```


### PR DESCRIPTION
Currently, there are a bunch of useful docs that are not included on the project website (and, as such, are not indexed so that they can be searched).

I've written a script (which can be run periodically, and would be ideal to be run by a bot) and made a few commits to fix this visibility issue:

- added a script to fetch the latest versions of selected documents from the Cockpit git source and project wiki
- committed current version of docs
- pointed the contribute nav link to the included document

A nice side-effect of these changes is that we can have all the navigation at the top of the page stay within the website as well.