### PR TITLE
fixed Jekyll commmand

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,10 +47,8 @@ In order to convert content into web pages, you will need to have Ruby, Bundler,
 
 3. Run Jekyll:
    ```
-   bundle exec jekyll
+   bundle exec jekyll server
    ```
-   
-   _(Note: If you don't have a system-wide install, you should be able to just type `jekyll`)_
 
 ## Work with the Site
 


### PR DESCRIPTION
Either the command changed in Jekyll to not default to `server`, or I was remembering Middleman instructions when I wrote this. :wink: