### PR TITLE
added CSS fallback to static for browsers that don't support sticky

### DIFF
--- a/assets/site.sass
+++ b/assets/site.sass
@@ -517,6 +517,10 @@ html.cockpit-guide
     margin-bottom: 0
 
   table.navigation
+    /* First fallback for Safari/Epiphany/non-sticky-browsers
+    /* (!important is used to override guide CSS)
+    position: static !important
+    /* Use sticky override for browsers that support it
     position: sticky !important
 
     @media screen and (min-width: $on-laptop)


### PR DESCRIPTION
This fixes Epiphany and should also fix Safari (which is basically its sibling in the browser world, as they share the same rendering engine).