### PR TITLE
running: Fix Atomic install instructions

### DIFF
--- a/running.md
+++ b/running.md
@@ -80,6 +80,7 @@ Alternatively you can access Cockpit directly on the Atomic Host if SSH password
 
 1. Run the Cockpit web service container: 
 ```
+sudo atomic install cockpit/ws
 sudo atomic run cockpit/ws
 ```
 {% endcapture %}


### PR DESCRIPTION
`atomic install` is explicitly necessary, otherwise it does not get
properly installed.

Fixes #116