### PR TITLE
blog: display articles in a grid

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -25,7 +25,7 @@ description: > # this means to ignore newlines until "baseurl:"
 
 #permalink: blog/:year/:month/:slug/
 permalink: blog/:slug.html
-paginate: 10
+paginate: 12
 paginate_path: "/blog/page=:num"
 
 # Ignore certain phrases from the blog listing (comma-separated)

--- a/assets/site.sass
+++ b/assets/site.sass
@@ -608,3 +608,13 @@ html.cockpit-guide
     opacity: 0
   100%
     opacity: 1
+
+/* Display the article list in a grid
+@supports (display: grid)
+  .blog-posts-list > .articles
+    display: grid
+    grid-template-columns: repeat(auto-fill, minmax(18rem, 1fr))
+    grid-gap: 2rem
+
+    > article
+      margin: 0 !important


### PR DESCRIPTION
Making the articles wrap nicely, thanks to CSS grids (in browsers that support it, which is everything but IE). It also changes pagination from 10 to 12 — which is nice, as it's a multiple of both 2 and 3 (meaning grids 3 items wide and 2 items wide both wrap perfectly).

For non-grid-supporting browsers, this changes nothing but pagination to include 2 more items.

(Browsers support unprefixed grid are at 90% — the only notible browsers that do not are IE, old versions of Edge (before Oct 2017), Opera Mini and Android versions below 4. In the case of mobile browsers, this changes nothing but pagination count anyway. This change is mainly for desktop and tablet users.)

See: https://caniuse.com/#feat=css-grid for browser support details.