### PR TITLE
running: bumped up browser requirements to IE11

### DIFF
--- a/running.md
+++ b/running.md
@@ -184,7 +184,7 @@ sudo systemctl enable --now cockpit.socket
 - {:.col}![](/images/site/browser-firefox.svg) Mozilla Firefox 11+
 - {:.col}![](/images/site/browser-chrome.svg) Google Chrome 16+
 - {:.col}![](/images/site/browser-edge.svg) Microsoft Edge
-- {:.col}![](/images/site/browser-explorer.svg) Microsoft Internet Explorer 10+
+- {:.col}![](/images/site/browser-explorer.svg) Microsoft Internet Explorer 11
 - {:.col}![](/images/site/browser-ios.svg) Apple iOS Safari 6.1+
 - {:.col}![](/images/site/browser-opera.svg) Opera 21.1+
 


### PR DESCRIPTION
- IE10 is completely dead, even according to Microsoft. 
- We use several features that are really dodgy, if supported at all in IE10.
- IE11 is the last version, so there's no `+` anymore.