### PR TITLE
blog: make atom feeds more discoverable

### DIFF
--- a/blog/feeds/index.md
+++ b/blog/feeds/index.md
@@ -2,7 +2,7 @@
 title: Atom Feeds
 ---
 
-Follow along in an feed reader! Subscribe to our Atom (similar to RSS) feed:
+Follow [the blog](/blog/) in an feed reader! Subscribe to our Atom (similar to RSS) feed:
 
 - [All blog posts](all.atom.xml)
 

--- a/blog/index.html
+++ b/blog/index.html
@@ -3,5 +3,11 @@ title: Blog posts
 index: false
 ---
 
+{% capture md %}
+You can also [Subscribe to Atom feeds](/blog/feeds/) in a feed reader.
+{% endcapture %}
+
+{{ md | markdownify }}
+
 {% include posts.html posts=paginator.posts %}
 {% include pagination.html %}

--- a/index.md
+++ b/index.md
@@ -50,7 +50,10 @@ You can monitor and administer several servers at the same time. Just add it eas
 About Cockpit
 : [Project Ideals and Goals](ideals.html)
 : [Cockpit Blog](blog)
+: [Blog Feeds](blog/feeds/)
 : [Search this site](search.html)
+
+*[Feeds]: Atom (similar to RSS), for use in feed readers
 {% endcapture %}
 
 {% capture footer_links_2 %}


### PR DESCRIPTION
- added link to front page's mini-footer
- added link on /blog/
- added link to /blog/ on /blog/feeds/