### PR TITLE
blog: fixed blog links with baseurls

### DIFF
--- a/blog/feeds/index.md
+++ b/blog/feeds/index.md
@@ -2,7 +2,7 @@
 title: Atom Feeds
 ---
 
-Follow [the blog](/blog/) in an feed reader! Subscribe to our Atom (similar to RSS) feed:
+Follow [the blog]({{ site.baseurl }}/blog/) in an feed reader! Subscribe to our Atom (similar to RSS) feed:
 
 - [All blog posts](all.atom.xml)
 

--- a/blog/index.html
+++ b/blog/index.html
@@ -4,7 +4,7 @@ index: false
 ---
 
 {% capture md %}
-You can also [Subscribe to Atom feeds](/blog/feeds/) in a feed reader.
+You can also [Subscribe to Atom feeds]({{ site.baseurl }}/blog/feeds/) in a feed reader.
 {% endcapture %}
 
 {{ md | markdownify }}


### PR DESCRIPTION
I added a few minor fixups to make these blog-related links work on baseurls that aren't domains (that is: on people's forks that serve as staging sites).

_Usually_ this is automatically handled by some magic I wrote in the layout code — but, as you can see, not always.