### PR TITLE
publish articles with a date/time set in the future

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -28,6 +28,9 @@ permalink: blog/:slug.html
 paginate: 12
 paginate_path: "/blog/page=:num"
 
+# Publish articles with a date/time set in the future
+future: true
+
 # Ignore certain phrases from the blog listing (comma-separated)
 blog_ignore: "We release regularly,Here are the release notes,Try it out,From the future,Note:,Cockpit is a user interface for servers"
 


### PR DESCRIPTION
Documentation: https://jekyllrb.com/docs/configuration/#build-command-options

Default is "false". We want "true", just in case the time is a little in the future. (Timezones could possibly get in the way otherwise.)