### PR TITLE
strip HTML from title strings

### DIFF
--- a/_layouts/essential.html
+++ b/_layouts/essential.html
@@ -6,7 +6,7 @@
     <meta name="viewport" content="width=device-width initial-scale=1" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
 
-    <title>{% if page.title %}{{ page.title }} &mdash; {% endif %}{{ site.title }}</title>
+    <title>{% if page.title %}{{ page.title | strip_html }} &mdash; {% endif %}{{ site.title | strip_html }}</title>
 
     <link rel="canonical" href="{{ page.url | replace:'index.html','' | prepend: site.baseurl | prepend: site.url }}">
 


### PR DESCRIPTION
In working with some HTML PCP mockups in Mockweb, I noticed that `<title>` would sometimes bring in (escaped) HTML tags. I changed it there, so I ported the fix here too.

This fix prevents the title on browser tabs from showing the HTML tags like this:
`Cockpit <strong>test</strong>` — now it would display `Cockpit test`