### PR TITLE
running: Update install instructions for RHEL

### DIFF
--- a/running.md
+++ b/running.md
@@ -70,12 +70,14 @@ sudo firewall-cmd --add-service=cockpit --permanent
 ### Red Hat Enterprise Linux
 {:#rhel}
 
-Cockpit is included in the Red Hat Enterprise Linux _Extras_ repository in versions 7.1 and later:
+Cockpit is included in Red Hat Enterprise Linux 7 and later.
 
-1. Enable the _Extras_ repository: 
+1. On RHEL 7, enable the _Extras_ repository.
 ```
 sudo subscription-manager repos --enable rhel-7-server-extras-rpms
 ```
+RHEL 8 does not need any non-default repositories.
+
 2. Install cockpit: 
 ```
 sudo yum install cockpit
@@ -84,7 +86,7 @@ sudo yum install cockpit
 ```
 sudo systemctl enable --now cockpit.socket
 ```
-4. Open the firewall if necessary:
+4. On RHEL 7, or if you use non-default zones on RHEL 8, open the firewall:
 ```
 sudo firewall-cmd --add-service=cockpit
 sudo firewall-cmd --add-service=cockpit --permanent


### PR DESCRIPTION
For RHEL ≥ 7.5, parts of Cockpit are in Base, but we still want to
recommend Extras to get cockpit-packagekit, and be able to install
cockpit-machines.

On RHEL 8, AppStream is enabled by default, and not having it is not
supported. So clarify that this first step only applies to 7.

On RHEL 8, the default zone has the Cockpit port opened in firewalld.
But point out that with custom zones it needs to be opened.

Fixes #242

----
Rendered preview: https://martinpitt.github.io/cockpit-project.github.io/running.html#rhel