### PR TITLE
Update F30 link in Cockpit 195 release notes

### DIFF
--- a/_posts/2019-05-29-cockpit-195.md
+++ b/_posts/2019-05-29-cockpit-195.md
@@ -72,4 +72,4 @@ Cockpit 195 is available now:
 
  * [For your Linux system](https://cockpit-project.org/running.html)
  * [Source Tarball](https://github.com/cockpit-project/cockpit/releases/tag/195)
- * [Fedora 30](https://bodhi.fedoraproject.org/updates/cockpit-195-1.fc30)
+ * [Fedora 30](https://bodhi.fedoraproject.org/updates/FEDORA-2019-553472e6c2)


### PR DESCRIPTION
The direct link to the package name and version doesn't seem to be
working anymore, so link directly to the build ID.