### PR TITLE
Cockpit 198: Fix bodhi URL

### DIFF
--- a/_posts/2019-07-10-cockpit-198.md
+++ b/_posts/2019-07-10-cockpit-198.md
@@ -77,6 +77,6 @@ Cockpit 198 is available now:
 
  * [For your Linux system](https://cockpit-project.org/running.html)
  * [Source Tarball](https://github.com/cockpit-project/cockpit/releases/tag/198)
- * [Fedora 30](https://bodhi.fedoraproject.org/updates/cockpit-198-1.fc30)
+ * [Fedora 30](https://bodhi.fedoraproject.org/updates/FEDORA-2019-2284294b43)
 
 *[VM]: Virtual Machine


### PR DESCRIPTION
Apparently the package version links have stopped working.