### PR TITLE
Add toolbox-based container scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 _site
+.gem
 .sass-cache
 .jekyll-metadata
 *.pyc

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ In order to convert content into web pages, you will need to have Ruby, Bundler,
    * **Fedora** / **RHEL** / **CentOS**:
      ```
      dnf install -y rubygem-bundler ruby-devel libffi-devel make gcc gcc-c++ \
-     redhat-rpm-config zlib-devel libxml2-devel libxslt-devel tar
+     redhat-rpm-config zlib-devel libxml2-devel libxslt-devel tar nodejs
      ```
 
    * **openSUSE**:

--- a/README.md
+++ b/README.md
@@ -8,6 +8,43 @@ For more details on Springboard, see [jekyll-springboard](https://github.com/gar
 
 ## Get Started
 
+### Fedora fast-track using a "toolbox" container
+
+#### Setting up the container for the first time
+
+0. Install toolbox (if you haven't already — it's preinstalled with Silverblue):
+   `sudo dnf install toolbox`
+1. Create the container and install the dependencies with:
+   `_scripts/toolbox-create`
+
+#### Running the Jekyll server locally
+
+Run the website locally using Jekyll with:
+
+1. `_scripts/toolbox-run`
+2. Visit <http://127.0.0.1:4000/>
+
+You can pass arguments to the run command. To see everything available, pass `--help`.
+The most useful arguments are:
+- `-I` for incremental, which speeds up page compilation by recompiling only parts that have changed
+- `-l` for livereload, which updates the browser when parts of the page change
+
+So, for instant rendering of local changes, you'd run:
+
+- `_scripts/toolbox-run -Il`
+
+#### Updating when Gemfile / Gemfile.lock changes
+
+1. `_scripts/toolbox-update`
+
+#### Deleting the container
+
+1. `_scripts/toolbox-delete`
+
+This removes the container and the local `.gem` directory.
+
+### Installing locally without a container
+
 In order to convert content into web pages, you will need to have Ruby, Bundler, and Jekyll installed.
 
 1. Install Ruby & Bundler (as root):

--- a/_scripts/toolbox-create
+++ b/_scripts/toolbox-create
@@ -1,0 +1,21 @@
+#!/usr/bin/bash -e
+
+echo "## Creating website container..."
+toolbox create -c cockpit-website
+
+run="toolbox run -c cockpit-website"
+
+echo "## Installing RPM dependencies inside container..."
+$run sudo dnf install -y rubygem-bundler \
+	ruby-devel libffi-devel make gcc gcc-c++ redhat-rpm-config zlib-devel \
+	libxml2-devel libxslt-devel tar nodejs
+
+echo "## Setting local gem path"
+$run bundle config path .gem
+
+echo "## Installing local gems"
+
+$run bundle install
+
+echo "## Done!"
+echo "## Run _scripts/toolbox-run"

--- a/_scripts/toolbox-delete
+++ b/_scripts/toolbox-delete
@@ -1,0 +1,8 @@
+#!/usr/bin/bash -e
+
+echo "## Deleting Cockpit website container..."
+
+toolbox rm -f cockpit-website
+rm -rf .gem
+
+echo "## Done! "

--- a/_scripts/toolbox-run
+++ b/_scripts/toolbox-run
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+toolbox run -c cockpit-website bundle exec jekyll server $@

--- a/_scripts/toolbox-update
+++ b/_scripts/toolbox-update
@@ -1,0 +1,10 @@
+#!/usr/bin/bash -e
+
+echo "## Updating Cockpit website container..."
+
+run="toolbox run -c cockpit-website"
+
+$run bundle install
+
+echo "## Done!"
+echo "## Run _scripts/toolbox-run"


### PR DESCRIPTION
- Added scripts to run the website locally in a toolbox container
- Made git ignore the local .gem directory (where I told toolbox to store its gems)
- Updated README with nodejs fix, as CoffeeScript needs a JavaScript engine, to align with container script deps

Fixes #263 