### PR TITLE
Removed unnecessary padding blocking click in Guide, class .chapters

### DIFF
--- a/assets/site/guide.sass
+++ b/assets/site/guide.sass
@@ -141,8 +141,7 @@ html.cockpit-guide
       text-decoration: underline
 
   h2, h3, h4, h5, h6,
-  dl.toc .part,
-  dl.toc .chapter,
+  dl.toc .part
     position: static
     padding: 1rem 0 0.5rem
 

--- a/assets/site/guide.sass
+++ b/assets/site/guide.sass
@@ -149,7 +149,7 @@ html.cockpit-guide
   dl.toc .part
     font-size: 1.72rem
 
-  h3,
+  h3
     font-size: 1.4rem
 
   .refnamediv h2,


### PR DESCRIPTION
I noticed an issue with some elements 'overflowing' their padding property, with no apparent visual result that blocked clicking links. Issue was most apparent in the Features section. Tested this in Chrome and Firefox (both on Windows).

The fix involved removing padding from said element's class. There is no apparent visual changes in the page or in any other pages (classification was under the page so I didn't expect that).

**Before:**
<kbd>
![unclickable](https://user-images.githubusercontent.com/1234491/65911358-34823b00-e3d5-11e9-94ec-b5ee603c1c95.gif)
</kbd>

**After:**
<kbd>
![clickable](https://user-images.githubusercontent.com/1234491/65911733-b8d4be00-e3d5-11e9-91ec-727621975099.gif)
</kbd>

Also removed a stray comma.