### PR TITLE
update minimum Chrome version to 63

### DIFF
--- a/_data/browsers.yml
+++ b/_data/browsers.yml
@@ -6,7 +6,7 @@
 - chrome:
   vendor: Google
   name: Chrome
-  version: 57
+  version: 63
 
 - edge:
   vendor: Microsoft


### PR DESCRIPTION
This allows Cockpit to rely on Promise.prototype.finally() and get rid
of its last custom polyfill.

See https://github.com/cockpit-project/cockpit/issues/12151