### PR TITLE
running: Update Arch installation instructions

### DIFF
--- a/_data/distros.yml
+++ b/_data/distros.yml
@@ -46,3 +46,4 @@
 
 - archlinux:
   name: Arch Linux
+  included: true

--- a/running.md
+++ b/running.md
@@ -240,6 +240,10 @@ sudo systemctl enable --now cockpit.socket
 ### Arch Linux
 {:#archlinux}
 
-Cockpit can be found in the [Arch Community Repository](https://www.archlinux.org/packages/) as package [cockpit](https://www.archlinux.org/packages/community/x86_64/cockpit/).
+[Cockpit](https://www.archlinux.org/packages/community/x86_64/cockpit/) is included in [Arch Linux](https://www.archlinux.org/packages/):
+```
+sudo pacman -Sy cockpit
+sudo systemctl enable --now cockpit.socket
+```
 
 


### PR DESCRIPTION
Show the commands how to install and enable it.

The Community Repository is part of the official repositories, so tone
down the text to stop making it sound exceptional/unsupported.

Also mark cockpit as "included" for the same reason.

Preview: https://martinpitt.github.io/cockpit-project.github.io/running.html