### PR TITLE
running: Avoid partial upgrade in Arch installation instructions

### DIFF
--- a/running.md
+++ b/running.md
@@ -242,8 +242,8 @@ sudo systemctl enable --now cockpit.socket
 
 [Cockpit](https://www.archlinux.org/packages/community/x86_64/cockpit/) is included in [Arch Linux](https://www.archlinux.org/packages/):
 ```
-sudo pacman -Sy cockpit
+sudo pacman -S cockpit
 sudo systemctl enable --now cockpit.socket
 ```
 
-
+If the first command fails with "database file for ... does not exist", refresh/update your system with `sudo pacman -Syu` first.


### PR DESCRIPTION
`pacman -Sy <package>` is an unsupported operation that should be
avoided [1] as it can cause a partial upgrade of the system. Instead,
just document how to install only the cockpit package, and separately
document the (uncommon) case when repository indexes don't exist.

Thanks to NEXCydran for pointing this out!

[1] https://wiki.archlinux.org/index.php/System_maintenance#Partial_upgrades_are_unsupported

Fixes commit 36605790126
Fixes #313