### PR TITLE
Style fixes  (2020-06-30)

### DIFF
--- a/assets/site.sass
+++ b/assets/site.sass
@@ -80,6 +80,10 @@ h1, h2, h3, h4, h5, h6, blockquote, dl, ol, ul, figure, p, pre
 .page-content
   padding-top: 4rem
 
+  > .wrapper
+    padding-left: 1.5rem
+    padding-right: 1.5rem
+
   dl
     margin: 1em
 
@@ -519,7 +523,7 @@ article
     border-color: $link-color
     box-shadow: 0 0 2px $link-color
 
-/* Display the article list in a grid
+/* Display the article list in a grid */
 @supports (display: grid)
   .blog-posts-list > .articles
     display: grid

--- a/assets/site/guide.sass
+++ b/assets/site/guide.sass
@@ -163,16 +163,14 @@ html.cockpit-guide
   div.chapter,
   div.reference,
   div.refentry
-    padding: 4rem 1rem 0
-    max-width: calc(65rem - 2rem)
-    width: 100%
+    padding: 4rem 2rem 0
+    max-width: calc(65rem - 4rem)
     margin-right: auto
     margin-left: auto
     flex: auto
 
     @media screen and (max-width: $on-laptop)
-      padding: 4rem 0.5rem 0
-      max-width: calc(100vw - 1rem)
+      max-width: calc(100vw - 4rem)
 
   .refnamediv > table td
     padding: 0 !important

--- a/assets/site/guide.sass
+++ b/assets/site/guide.sass
@@ -224,3 +224,20 @@ html.cockpit-guide
     pre
       max-width: calc(100vw - 6rem)
       overflow: auto
+
+/* Adapt warnings to Cockpit's PF4 inspired style */
+div.warning
+  margin: 0 !important
+  padding: 0
+  display: grid
+  grid: auto 1fr / 1fr
+  grid-gap: 0.5rem
+  padding: 1rem
+
+  > .title
+  > h3,
+  > p
+    grid-column: -1
+    padding: 0
+    margin: 0
+    font-size: inherit

--- a/assets/site/guide.sass
+++ b/assets/site/guide.sass
@@ -36,6 +36,31 @@ html.cockpit-guide
       font-size: inherit
       line-height: inherit
 
+  /* Evil hack to deconstruct tables
+    as we don't have any way to rewrite the HTML here, it's pretty bad
+    but the variable list doesn't use semantic tables anyway
+    so a11y is questionable at best
+    it really should be a dl (with dt, dd)
+
+  div.variablelist
+    th, td
+      padding: 0
+
+    @media screen and (max-width: $on-laptop)
+      table tr
+        display: flex
+        flex-direction: column
+
+        .term
+          display: block
+          margin-bottom: 0.5rem
+
+        &:not(:last-child)
+          margin-bottom: 3rem
+
+        p:last-child
+          margin-bottom: 0 !important
+
   header.masthead
     margin-bottom: 0
 


### PR DESCRIPTION
- Add a little more edge padding for narrow screens (small width desktop and mobile
- Deconstruct variable list for mobile, stacking the list when too narrow for side-by-side
- Fix the documentation warnings to match the warnings used on the site