### PR TITLE
Document that cockpit/ws image needs to be pulled

### DIFF
--- a/running.md
+++ b/running.md
@@ -152,6 +152,7 @@ The standard Fedora CoreOS image does not contain Cockpit packages.
 
 3. Run the Cockpit web service with this privileged container (as root):
    ```
+   podman pull cockpit/ws
    podman container runlabel --name cockpit-ws RUN cockpit/ws
    ```
 


### PR DESCRIPTION
It seems that podman does not pull images on `container runlabel` command.

Fixes https://github.com/cockpit-project/cockpit/issues/14481