### PR TITLE
Warning fixups: Layout and spacing

### DIFF
--- a/assets/site/guide.sass
+++ b/assets/site/guide.sass
@@ -241,3 +241,6 @@ div.warning
     padding: 0
     margin: 0
     font-size: inherit
+
+  + p
+    margin-top: 1rem

--- a/assets/site/guide.sass
+++ b/assets/site/guide.sass
@@ -230,7 +230,7 @@ div.warning
   margin: 0 !important
   padding: 0
   display: grid
-  grid: auto 1fr / 1fr
+  grid-template-columns: max-content
   grid-gap: 0.5rem
   padding: 1rem
 


### PR DESCRIPTION
Fixes documentation warning layout issue in https://cockpit-project.org/guide/latest/embedding.html#embedding-deep and adds spacing between a warning and a paragraph for https://cockpit-project.org/guide/latest/cert-authentication.html#certauth-server-cockpitconf