### PR TITLE
Update external docs (2020-11-24)

### DIFF
--- a/external/bots/README.md
+++ b/external/bots/README.md
@@ -136,11 +136,11 @@ You can also invoke bots/tests/trigger from any project checkout, in which case
 you don't need the explicit `--repo` -- it will default to the GitHub origin of
 the current directory's project.
 
-### Testing a pull request by a non-whitelisted user
+### Testing a pull request by a non-allowed user
 
-If you want to run all tests on pull request #1234 that has been
-opened by someone who is not in our white-list, run tests-trigger
-with `--allow`:
+If you want to run all tests on pull request #1234 that has been opened by someone
+who does not have push access to the repository nor isn't in the 'Contributors' team,
+run tests-trigger with `--allow`:
 
     $ ./tests-trigger --allow [...]
 

--- a/external/source/HACKING.md
+++ b/external/source/HACKING.md
@@ -209,35 +209,6 @@ You need to disable SELinux with
 for this to work, as your local build tree does not otherwise have the expected
 SELinux type.
 
-## Working on Cockpit using Vagrant
-
-It is also possible to use a Vagrant virtual machine to develop Cockpit.
-
-Most of Cockpit is written in JavaScript. Almost all of this code is found
-in the packages in the pkg/ subdirectory of the Cockpit git checkout.
-
-To use Vagrant to develop Cockpit, run in its top level git checkout.
-In some cases you may need to use `sudo` with vagrant commands:
-
-    $ vagrant up
-
-Now you can edit files in the `pkg/` subdirectory of the Cockpit sources.  Use
-`make` to build those sources. The changes should take effect after syncing
-them to the Vagrant VM. For example:
-
-    $ make && vagrant rsync
-
-Now log into Cockpit on the vagrant VM to see your changes. Use the
-user name 'admin' and the password 'foobar' to log in. The Cockpit
-instance in vagrant should be available at the following URL:
-
-http://localhost:9090
-
-If you want to setup automatic syncing as you edit JavaScript files
-you can run:
-
-    $ vagrant rsync-auto &
-
 ## Installation from upstream sources
 
     $ make
@@ -252,6 +223,21 @@ that `make install` not write outside that prefix, then specify the
 `--enable-prefix-only` option to `autogen.sh`. This will result in an
 installation of Cockpit that does not work without further tweaking.
 For advanced users only.
+
+## Build distribution packages
+
+Instead of a direct `make install` as above, you can also build distribution
+packages and install them. This is generally more robust, as they upgrade and
+remove cleanly, and don't interfere with distribution packages in `/usr`.
+
+In a Fedora/RHEL build environment you can build binary RPMs with
+
+    tools/make-rpms --quick
+
+In a Debian/Ubuntu build environment you can build debs with
+
+    cp -r tools/debian .
+    dpkg-buildpackage -us -uc -b
 
 ## Contributing a change
 

--- a/external/source/test/README.md
+++ b/external/source/test/README.md
@@ -78,16 +78,18 @@ You can set these environment variables to configure the test suite:
                   "centos-8-stream"
                   "debian-stable"
                   "debian-testing"
-                  "fedora-31"
                   "fedora-32"
+                  "fedora-33"
                   "fedora-coreos"
                   "fedora-testing"
                   "rhel-7-9"
                   "rhel-8-3"
                   "rhel-8-3-distropkg"
+                  "rhel-8-4"
+                  "rhel-atomic"
                   "ubuntu-2004"
                   "ubuntu-stable"
-               "fedora-31" is the default (bots/machine/machine_core/constants.py)
+               "fedora-32" is the default (bots/machine/machine_core/constants.py)
 
     TEST_JOBS  How many tests to run in parallel.  The default is 1.
 


### PR DESCRIPTION
Updated to the latest external docs with the following command:

```sh
toolbox run -c cockpit-website sh -c _scripts/update-external-docs.rb
```

(Which should work on every system when there's a cockpit-website container, made with `_scripts/toolbox-create`.)