### PR TITLE
running: Fix install instructions for Fedora CoreOS

### DIFF
--- a/running.md
+++ b/running.md
@@ -152,13 +152,12 @@ The standard Fedora CoreOS image does not contain Cockpit packages.
 
 3. Run the Cockpit web service with this privileged container (as root):
    ```
-   podman pull cockpit/ws
-   podman container runlabel --name cockpit-ws RUN cockpit/ws
+   podman container runlabel --name cockpit-ws RUN docker.io/cockpit/ws
    ```
 
 4. Make Cockpit start on boot:
    ```
-   podman container runlabel INSTALL cockpit/ws
+   podman container runlabel INSTALL docker.io/cockpit/ws
    systemctl enable cockpit.service
    ```
 


### PR DESCRIPTION
podman on Fedora CoreOS has stopped looking into the docker.io registry
by default, so that a bare "cockpit/ws" would just check
registry.fedoraproject.org.

This was fixed half a year ago in cockpit [1], but forgotten to be moved
to the website.

[1] https://github.com/cockpit-project/cockpit/commit/2256ae091ee731f

Fixes #360