### PR TITLE
workflows: Weekly update of external pages

### DIFF
--- a/.github/workflows/update-externals.yml
+++ b/.github/workflows/update-externals.yml
@@ -1,0 +1,30 @@
+name: Update external pages
+on:
+  schedule:
+    - cron: '30 1 * * 4'
+  workflow_dispatch:
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v2
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y ruby-bundler
+
+      - name: Run update script
+        run: _scripts/update-external-docs.rb
+
+      - name: Create pull request
+        uses: peter-evans/create-pull-request@v3
+        with:
+          title: Update external docs
+          body: ''
+          commit-message: Update external docs
+          # do *not* use any suffix here -- if there is an open unreviewed PR,
+          # we want to force-push to that, not create a new one
+          branch: update-externals


### PR DESCRIPTION
Run update-external-docs.rb every Thursday, or on manual request.

Fixes #151

-----

I tested this on my fork:

  - Until this morning, docs were up to date. My [first run](https://github.com/martinpitt/cockpit-project.github.io/actions/runs/429838721) saw no changes and did not create a pull request, see [this log line](https://github.com/martinpitt/cockpit-project.github.io/runs/1575041303?check_suite_focus=true#step:5:463)
  - I [made a fix to our Workflow wiki page](https://github.com/cockpit-project/cockpit/wiki/Workflow/_compare/920ed9cc6de0b4f438dfbb2c85a103182ba592b5)
  - Then I [ran this workflow](https://github.com/martinpitt/cockpit-project.github.io/actions/runs/429838721) again, and it created https://github.com/martinpitt/cockpit-project.github.io/pull/3