### PR TITLE
include: Handle source override in GitHub edit

### DIFF
--- a/_includes/github.html
+++ b/_includes/github.html
@@ -1,13 +1,20 @@
 {% if site.github %}{% capture github_link %}
   {% assign github_edit_text = site.github_edit_text | default: "Edit page on GitHub" %}
-  <a
-    href="https://github.com/{{
-      site.github.owner_name
-    }}/{{
-      site.github.repository_name
-    }}/edit/master/{{
-      page.path
-    }}">{{
-      github_edit_text
-    }}</a>
+  {% if page.source %}
+    {% if page.source contains '/wiki/' %}
+      {% assign wiki = '/_edit'%}
+    {% endif %}
+    <a href="{{ page.source | replace_first: '/blob/', '/edit/' }}{{ wiki }}">{{ github_edit_text }}</a>
+  {% else %}
+    <a
+      href="https://github.com/{{
+        site.github.owner_name
+      }}/{{
+        site.github.repository_name
+      }}/edit/master/{{
+        page.path
+      }}">{{
+        github_edit_text
+      }}</a>
+  {% endif %}
 {% endcapture %}{{ github_link | strip_new_lines | lstrip | rstrip }}{% endif %}


### PR DESCRIPTION
Fixes #235

Includes support for both repo and wiki links. The link is to the edit mode on GitHub.

Our externals script has included "source:" with URLs in the frontmatter this whole time, with anticipation of this support. :wink: 