### PR TITLE
running: Adjust breakpoint for OS table

### DIFF
--- a/assets/site.sass
+++ b/assets/site.sass
@@ -273,9 +273,9 @@ html.running-cockpit
         width: 0
         white-space: nowrap
 
-    @media screen and (max-width: 40rem)
+    @media screen and (max-width: 46rem)
       a
-        padding: 0 1ch
+        padding: 1ch
 
       th:not(:first-child)
         font-size: 0.85rem


### PR DESCRIPTION
I was going to address #231 but looked at the running page instead. I noticed it did have horizontal overflow due to the breakpoint being a little off. I've fixed it, even though it's unrelated to the original issue (which I think was fixed in another commit, a long while ago).