### PR TITLE
include/feed: Use absolute URL for images

### DIFF
--- a/_includes/feed.html
+++ b/_includes/feed.html
@@ -4,23 +4,33 @@ assign posts = include.posts | default: site.posts
 assign limit = include.limit | default: site.paginate | default: 10
 %}{%
 assign title = include.title | default: site.title
+%}{%
+assign url_prefix = site.url | append: site.baseurl | append: '/'
 %}<?xml version="1.0" encoding="UTF-8"?>
 <rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
   <channel>
     <title>{{ title | xml_escape }}</title>
     <description>{{ site.description | xml_escape }}</description>
-    <link>{{ site.url }}{{ site.baseurl }}/</link>
-    <atom:link href="{{ "/feed.xml" | prepend: site.baseurl | prepend: site.url }}" rel="self" type="application/rss+xml"/>
+    <link>{{ url_prefix }}</link>
+    <atom:link href="{{ "/feed.xml" | prepend: url_prefix }}" rel="self" type="application/rss+xml"/>
     <pubDate>{{ site.time | date_to_rfc822 }}</pubDate>
     <lastBuildDate>{{ site.time | date_to_rfc822 }}</lastBuildDate>
     <generator>Jekyll v{{ jekyll.version }}</generator>
     {% for post in posts limit: limit %}
       <item>
         <title>{{ post.title | xml_escape }}</title>
-        <description>{{ post.content | markdownify | xml_escape }}</description>
+        <description>
+          {{ post.content
+            | markdownify
+            | replace: 'img src="/', 'img src="$SITE_GOES_HERE'
+            | replace: 'a href="/', 'a href="$SITE_GOES_HERE'
+            | replace: '$SITE_GOES_HERE', url_prefix
+            | xml_escape
+          }}
+        </description>
         <pubDate>{{ post.date | date_to_rfc822 }}</pubDate>
-        <link>{{ post.url | prepend: site.baseurl | prepend: site.url }}</link>
-        <guid isPermaLink="true">{{ post.url | prepend: site.baseurl | prepend: site.url }}</guid>
+        <link>{{ post.url | prepend: url_prefix }}</link>
+        <guid isPermaLink="true">{{ post.url | prepend: url_prefix }}</guid>
         {% for tag in post.tags %}
         <category>{{ tag | xml_escape }}</category>
         {% endfor %}

--- a/_includes/feed.html
+++ b/_includes/feed.html
@@ -12,7 +12,7 @@ assign url_prefix = site.url | append: site.baseurl | append: '/'
     <title>{{ title | xml_escape }}</title>
     <description>{{ site.description | xml_escape }}</description>
     <link>{{ url_prefix }}</link>
-    <atom:link href="{{ "/feed.xml" | prepend: url_prefix }}" rel="self" type="application/rss+xml"/>
+    <atom:link href="{{ page.url | remove_first: '/' | prepend: url_prefix }}" rel="self" type="application/rss+xml"/>
     <pubDate>{{ site.time | date_to_rfc822 }}</pubDate>
     <lastBuildDate>{{ site.time | date_to_rfc822 }}</lastBuildDate>
     <generator>Jekyll v{{ jekyll.version }}</generator>


### PR DESCRIPTION
Some feed readers support referencing images relative to the `<link>` as `<base href>`,  others do not.

By changing our path referenced images to be absolute instead, _all_ feed readers will be supported (provided they stick to https to avoid mixed content, but that's on their side, not ours).