### PR TITLE
guide: Fix typo in CSS (missing comma)

### DIFF
--- a/assets/site/guide.sass
+++ b/assets/site/guide.sass
@@ -230,7 +230,7 @@ div.warning
   margin: 0 !important
   padding: var(--alert-padding)
 
-  > .title
+  > .title,
   > h3,
   > p
     padding: 0


### PR DESCRIPTION
Super simple fix: I missed a comma on the title class. Whoops!