### PR TITLE
browser: Update browser checks for replaceAll

### DIFF
--- a/_data/browser_support.yml
+++ b/_data/browser_support.yml
@@ -49,6 +49,10 @@ rules:
     req:
     - supports
     - window.CSS
+  replaceAll:
+    req:
+    - replaceAll
+    - String.prototype
   flexbox:
     css:
     - display

--- a/_data/browsers.yml
+++ b/_data/browsers.yml
@@ -1,17 +1,20 @@
 - firefox:
   vendor: Mozilla
   name: Firefox
+  version: 77
 
 - chrome:
   vendor: Google
   name: Chrome
+  version: 85
 
 - edge:
   vendor: Microsoft
   name: Edge
+  version: 85
 
 - safari:
   vendor: Apple
   os: iOS
   name: Safari
-  version: 10.3
+  version: 13.4

--- a/_scripts/update-browser-data.rb
+++ b/_scripts/update-browser-data.rb
@@ -47,6 +47,11 @@ supports = YAML.load("
     #promise-finally:
         #req: [finally, Promise.prototype]
 
+    ## `replaceAll` isn't in the caniuse compiled database at the moment (oversight)
+    ## Adding it here strictly for the live in-browser JavaScript check (as a passthrough)
+    replaceAll:
+        req: [replaceAll, String.prototype]
+
     flexbox:
         css: [display, flex]
 
@@ -54,7 +59,7 @@ supports = YAML.load("
         css: [display, grid]
 ")
 
-caniuse_db = "https://raw.githubusercontent.com/Fyrd/caniuse/master/data.json"
+caniuse_db = "https://raw.githubusercontent.com/Fyrd/caniuse/main/data.json"
 support_file = File.expand_path "#{__dir__}/../_data/" + "browser_support.yml"
 
 puts "Downloading caniuse database..."
@@ -69,8 +74,10 @@ browsers = {}
 terminator = 999999
 
 supports.each do |support, vals|
-    #puts support[0]
-    data[support]["stats"].each do |browser, version|
+    # First check to see if the support data is in the caniuse DB.
+    # It really should be, but sometimes it's missing something.
+    # Regardless, it needs to be passed through still, for the live JS browser check.
+    data[support] && data[support]["stats"].each do |browser, version|
         # Edge _almost_ supports @supports API; close enough for us
         if (support == "css-supports-api")
             low_version = version.reject {|k,v| v == "n"}.keys.first


### PR DESCRIPTION
- Switch caniuse DB URL to 'main'
- Add replaceAll check (even though it isn't in caniuse db)
- Manually bump up minimum browser versions
- Update browser support data from script