### PR TITLE
running: Document how to enable password SSH logins on CoreOS

### DIFF
--- a/running.md
+++ b/running.md
@@ -160,18 +160,26 @@ The standard Fedora CoreOS image does not contain Cockpit packages.
 
 2. Reboot
 
-3. Run the Cockpit web service with this privileged container (as root):
+Steps 1 and 2 are enough when the CoreOS machine is only connected to through another host running Cockpit.
+
+If you want to also run a web server to log in directly on the CoreOS host:
+
+3. Enable password based SSH logins, unless you only use [SSO logins](https://cockpit-project.org/guide/latest/sso.html):
+   ```
+   echo 'PasswordAuthentication yes' | sudo tee /etc/ssh/sshd_config.d/02-enable-passwords.conf
+   sudo systemctl try-restart sshd
+   ```
+
+4. Run the Cockpit web service with a privileged container (as root):
    ```
    podman container runlabel --name cockpit-ws RUN docker.io/cockpit/ws
    ```
 
-4. Make Cockpit start on boot:
+5. Make Cockpit start on boot:
    ```
    podman container runlabel INSTALL docker.io/cockpit/ws
    systemctl enable cockpit.service
    ```
-
-_Steps 3 and 4 are optional if the CoreOS machine will only be connected to from another host running Cockpit._
 
 Afterward, use a web browser to log into port `9090` on your host IP address as usual.
 


### PR DESCRIPTION
Same update as the cockpit/ws container documentation update:
https://github.com/cockpit-project/cockpit/commit/7a289865e7a

----

Preview: https://martinpitt.github.io/cockpit-project.github.io/running.html#coreos