### PR TITLE
Remove broken link to legacy Fedora packages services

### DIFF
--- a/running.md
+++ b/running.md
@@ -154,7 +154,7 @@ The standard Fedora CoreOS image does not contain Cockpit packages.
    rpm-ostree install cockpit-system cockpit-ostree cockpit-podman
    ```
 
-   Depending on your configuration, you may want to use [other extensions](https://apps.fedoraproject.org/packages/s/cockpit-) as well, such as `cockpit-kdump` or `cockpit-networkmanager`.
+   Depending on your configuration, you may want to use other `cockpit-*` extensions as well, such as `cockpit-kdump` or `cockpit-networkmanager`.
 
    If you have a custom-built OSTree, simply include the same packages in your build.
 


### PR DESCRIPTION
The Fedora packages app has been deprecated for a while for now,
see https://discussion.fedoraproject.org/t/https-apps-fedoraproject-org-packages-is-down-and-has-been-for-a-while/23662/3?u=rugk
The suggested alternative is https://src.fedoraproject.org.

Unfortunately, I also found no way to link to the cockpit packages as before. There is only the usual page and also no way to show dependencies:
https://src.fedoraproject.org/rpms/cockpit

As such I just removed the link.