### PR TITLE
script: Fix release note repo assumptions & formatting

### DIFF
--- a/_scripts/generate-release-notes.rb
+++ b/_scripts/generate-release-notes.rb
@@ -114,7 +114,7 @@ end
 def oxfordize(parts)
   case parts.size
   when 0..1
-    parts.to_s
+    parts.first
   when 2
     parts.join(' and ')
   else
@@ -238,7 +238,7 @@ end
 def headfoot(template)
   template
     .gsub('VERSIONS', oxfordize(@releases))
-    .gsub('ARE', @releases != 1 ? 'are' : 'is')
+    .gsub('ARE', @releases.count != 1 ? 'are' : 'is')
 end
 
 # Construct footer locations per repo, with version-specific URLs

--- a/_scripts/generate-release-notes.rb
+++ b/_scripts/generate-release-notes.rb
@@ -229,10 +229,9 @@ def find_terms(doc)
   end
 end
 
-# Reformat lower-case repo name to titlecase
+# Reformat repo name when appropriate
 def repo_human(repo)
-  repo.split('-').map(&:capitalize).join('-')
-      .sub('Ostree', 'OSTree')
+  repo.match('-') ? repo : repo.capitalize
 end
 
 # Generate headers and footers based on the template, with substitions for versions


### PR DESCRIPTION
Before I forget, here's a possible fix for handling project names with lowercasing, to make @allisonkarlitskaya happier.

I haven't tested it yet, as it's late today and I just want to be done with Release-Notes for now, but I also don't want to forget this.