### PR TITLE
Change samba-manager to file-sharing, and add navigator file browser

### DIFF
--- a/_data/applications.yml
+++ b/_data/applications.yml
@@ -165,7 +165,7 @@ file-sharing:
   official: false
   prerelease: false
   description: |
-    A Cockpit plugin to easily manage samba and NFS file sharing.
+    A Cockpit plugin to easily manage Samba and NFS file sharing.
 
 smb:
   title: SMB Plugin

--- a/_data/applications.yml
+++ b/_data/applications.yml
@@ -158,13 +158,14 @@ zfs:
   description: |
     An interactive ZFS on Linux admin package for Cockpit.
 
-samba:
-  title: Samba Manager
-  source: https://github.com/45Drives/cockpit-samba-manager
+file-sharing:
+  title: File Sharing
+  source: https://github.com/45Drives/cockpit-file-sharing
+  issues: https://github.com/45Drives/cockpit-file-sharing/issues
   official: false
-  prerelease: true
+  prerelease: false
   description: |
-    A Cockpit plugin to manage Samba shares and users. 
+    A Cockpit plugin to easily manage samba and NFS file sharing.
 
 smb:
   title: SMB Plugin
@@ -173,3 +174,13 @@ smb:
   prerelease: true
   description: |
     Manage your Samba shares through the Cockpit user interface.
+
+navigator:
+  title: Navigator
+  source: https://github.com/45Drives/cockpit-navigator
+  issues: https://github.com/45Drives/cockpit-navigator/issues
+  official: false
+  prerelease: false
+  description: |
+    A Featureful File Browser for Cockpit.
+ 

--- a/_data/applications.yml
+++ b/_data/applications.yml
@@ -184,3 +184,11 @@ navigator:
   description: |
     A Featureful File Browser for Cockpit.
  
+benchmark:
+  title: Benchmark
+  source: https://github.com/45Drives/cockpit-benchmark
+  issues: https://github.com/45Drives/cockpit-benchmark/issues
+  official: false
+  prerelease: false
+  description: |
+    A Storage Benchmark Utility for Cockpit.


### PR DESCRIPTION
45drives/cockpit-samba-manager is deprecated - use 45drives/cockpit-file-sharing instead. Also added cockpit-navigator, a useful file manager/browser; and cockpit-benchmark, a storage benchmark utility.  
[File Sharing](https://github.com/45Drives/cockpit-file-sharing)  
[Navigator](https://github.com/45Drives/cockpit-navigator)  
[Benchmark](https://github.com/45Drives/cockpit-benchmark)