### PR TITLE
script: Handle lack of release notes on main repo

### DIFF
--- a/_scripts/generate-release-notes.rb
+++ b/_scripts/generate-release-notes.rb
@@ -133,13 +133,15 @@ def drop_prefix(repo)
 end
 
 # Make frontmatter metadata based on logged in user and release notes
-def build_frontmatter(opts)
+def build_frontmatter
+  cockpit_title = "Cockpit #{@cockpit_version}"
+
   @frontmatter = {
-    title: opts[:title],
+    title: cockpit_title,
     author: Etc.getlogin,
     date: Time.now.strftime('%F'),
     tags: @tags.join(', '),
-    slug: opts[:slug],
+    slug: slugify(cockpit_title),
     category: 'release',
     summary: ''
   }.to_yaml.gsub(/^:/, '')
@@ -270,6 +272,7 @@ def process_repos
     # Process versions
     url_tags = tags_template.sub('REPO', repo)
     versions = get_json(url_tags).map { |tag| tag['name'].to_i }.sort
+    # Set the Cockpit version from the first repo (which is always Cockpit)
     @cockpit_version ||= versions.last + 1
 
     notes = get_json(url)['items']
@@ -286,7 +289,7 @@ def construct_all_the_notes
   # All the release note text
   release_notes = process_repos
 
-  build_frontmatter({ title: @releases.first, slug: slugify(@releases.first) })
+  build_frontmatter
 
   [
     @frontmatter, '---', "\n",


### PR DESCRIPTION
I moved the title string into the frontmatter, always basing it on Cockpit's own version, allowing for Cockpit itself to have no release-note tags and yet still generate proper release notes.

(Subprojects may have release-note tags still, even if Cockpit itself does not have anything noteworthy.)

Previous version would erroneously grab the first version of something with release notes, which works fine if Cockpit itself has release notes. Whoops.