### PR TITLE
Replace broken links with linux.die.net links

### DIFF
--- a/guide/latest/feature-pcp.html
+++ b/guide/latest/feature-pcp.html
@@ -36,8 +36,8 @@ layout: guide
     systemd unit is running or not. The "Enable PCP metrics collector" button on the
     "Performance Metrics" page will enable and start this service.</p>
 <p>To see similar metrics data from the command line, you can use tools like
-    <a class="ulink" href="https://pcp.io/books/PCP_UAG/html/LE38515-PARENT.html#LE91266-PARENT" target="_top"><code class="code">pmstat</code></a>
-    or <a class="ulink" href="https://pcp.io/books/PCP_UAG/html/LE60452-PARENT.html" target="_top"><code class="code">pminfo</code></a>:</p>
+    <a class="ulink" href="https://linux.die.net/man/1/pmstat" target="_top"><code class="code">pmstat</code></a>
+    or <a class="ulink" href="https://linux.die.net/man/1/pminfo" target="_top"><code class="code">pminfo</code></a>:</p>
 <pre class="programlisting">
 $ <span class="command"><strong>pmstat</strong></span>
 @ Sat Sep 26 15:30:10 2015


### PR DESCRIPTION
## All edits where made on the [PCP Metrics page](https://cockpit-project.org/guide/latest/feature-pcp.html) 

1. Changed `pmstat` link from [this](https://pcp.io/books/PCP_UAG/html/LE38515-PARENT.html#LE91266-PARENT) to [this](https://linux.die.net/man/1/pmstat) 
2. Changed `pminfo` link form [this](https://pcp.io/books/PCP_UAG/html/LE60452-PARENT.html) to  [this](https://linux.die.net/man/1/pmstat) 

If you feel that the updated links are not the best choice feel free to edit or drop them below. 