### PR TITLE
script: Bump toolbox-create script to Fedora 35

### DIFF
--- a/_scripts/toolbox-create
+++ b/_scripts/toolbox-create
@@ -1,7 +1,7 @@
 #!/bin/sh -e
 
 echo "## Creating website container..."
-toolbox create -c cockpit-website -r 34
+toolbox create -c cockpit-website -r 35
 
 run="toolbox run -c cockpit-website"
 


### PR DESCRIPTION
Fedora 35 beta's toolbox cannot currently run Fedora 34 containers. However, Fedora 34 and Fedora 35 both can run Fedora 35 containers and this script works perfectly well in Fedora 35, so I'm bumping the version.