### PR TITLE
Mention adjusted install command needed for Linux Mint

### DIFF
--- a/running.md
+++ b/running.md
@@ -239,6 +239,11 @@ We recommend installing or updating the latest version from backports. This repo
 sudo apt install -t ${VERSION_CODENAME}-backports cockpit
 ```
 
+On Linux Mint, use `UBUNTU_CODENAME` instead of `VERSION_CODENAME` like so:
+```
+sudo apt install -t ${UBUNTU_CODENAME}-backports cockpit
+```
+
 ### Clear Linux
 {:#clearlinux}
 


### PR DESCRIPTION
This PR adds a few lines to indicate that on Linux Mint, the `UBUNTU_CODENAME` variable is required rather than the `VERSION_CODENAME`.  Linux Mint defines its own version codename separate from Ubuntu's, so the backport command as-is fails.  Other Ubuntu-based distributions may do the same, but Linux Mint is probably the most important to note since it's one of the top five distributions.