### PR TITLE
blog: Improve subtitles in blog summary list

### DIFF
--- a/_includes/post.html
+++ b/_includes/post.html
@@ -69,20 +69,21 @@
     | strip
     %}
     {% if skip == '' %}
+      {% assign line_stripped = line | strip_html %}
       {% if line contains '<h' %}
-        {% assign content_headings = line 
-        | strip_html 
+        {% assign content_headings = line_stripped
         | prepend: '- ' 
         | prepend: newline 
         | prepend: content_headings
         %}
         {% assign content_stripped = content_stripped
-        | append: line
-        | append: newline
+        | append: ' <h3 class="post-content-subtitle">'
+        | append: line_stripped
+        | append: '</h3> '
+        | append: newline 
         %}
       {% else %}
-        {% assign content_stripped = line 
-        | strip_html 
+        {% assign content_stripped = line_stripped
         | prepend: content_stripped
         %}
       {% endif %}

--- a/assets/lib/blog.sass
+++ b/assets/lib/blog.sass
@@ -216,6 +216,13 @@ article.post
       padding-top: 1.5em
       display: block
 
+/* Blog post summary
+
+.blog-posts-list
+  .post-content-subtitle
+    font-size: inherit
+    margin: 1rem 0 0.5rem
+
 /* Pagination
 
 .blog-posts-list + nav > .pagination


### PR DESCRIPTION
This patch handles subheadings in a better way, by converting them to H3s (as the titles are H2s) and reformats the subheadings to be the same size as the text, with reduced space.

Before:

![Screenshot 2022-03-07 at 15-36-38 Blog posts — Cockpit Project](https://user-images.githubusercontent.com/10246/157054744-a3045535-c957-413a-af97-8e634267fb77.png)

After:

![Screenshot 2022-03-07 at 15-36-25 Blog posts — Cockpit Project](https://user-images.githubusercontent.com/10246/157054776-6c60896b-d9f1-4792-8b9e-5d1202ec9f83.png)