### PR TITLE
applications: Delist the old, unmaintained SMB app

### DIFF
--- a/_data/applications.yml
+++ b/_data/applications.yml
@@ -167,14 +167,6 @@ file-sharing:
   description: |
     A Cockpit plugin to easily manage Samba and NFS file sharing.
 
-smb:
-  title: SMB Plugin
-  source: https://github.com/enira/cockpit-smb-plugin
-  official: false
-  prerelease: true
-  description: |
-    Manage your Samba shares through the Cockpit user interface.
-
 navigator:
   title: Navigator
   source: https://github.com/45Drives/cockpit-navigator


### PR DESCRIPTION
Please note: The *maintained* Samba and NFS app is still here.