### PR TITLE
269: Link to specific releases

### DIFF
--- a/_posts/2022-05-12-cockpit-269.md
+++ b/_posts/2022-05-12-cockpit-269.md
@@ -40,12 +40,12 @@ Cockpit 269 and cockpit-machines 269 are available now:
 * [For your Linux system](https://cockpit-project.org/running.html)
 
 * [Cockpit Source Tarball](https://github.com/cockpit-project/cockpit/releases/tag/269)
-* [Cockpit Fedora 36](https://bodhi.fedoraproject.org/updates/?releases=F36&packages=cockpit)
-* [Cockpit Fedora 35](https://bodhi.fedoraproject.org/updates/?releases=F35&packages=cockpit)
+* [Cockpit Fedora 36](https://bodhi.fedoraproject.org/updates/FEDORA-2022-8204559683)
+* [Cockpit Fedora 35](https://bodhi.fedoraproject.org/updates/FEDORA-2022-911bd0f4a3)
 * [Cockpit Client](https://flathub.org/apps/details/org.cockpit_project.CockpitClient)
 * [cockpit-machines Source Tarball](https://github.com/cockpit-project/cockpit-machines/releases/tag/269)
-* [cockpit-machines Fedora 36](https://bodhi.fedoraproject.org/updates/?releases=F36&packages=cockpit-machines)
-* [cockpit-machines Fedora 35](https://bodhi.fedoraproject.org/updates/?releases=F35&packages=cockpit-machines)
+* [cockpit-machines Fedora 36](https://bodhi.fedoraproject.org/updates/FEDORA-2022-4b47be5825)
+* [cockpit-machines Fedora 35](https://bodhi.fedoraproject.org/updates/FEDORA-2022-fb2e44c08b)
 * [Cockpit Client](https://flathub.org/apps/details/org.cockpit_project.CockpitClient)
 
 *[CPU]: Central Processing Unit, the "brain" of a computer


### PR DESCRIPTION
Replace the bodhi search URLs with the links to the actual releases.
The search URLs are only meant to be used as a fallback in case we
forget.