### PR TITLE
externals: Add proxy wiki pages

### DIFF
--- a/_scripts/update-external-docs.rb
+++ b/_scripts/update-external-docs.rb
@@ -11,6 +11,8 @@ wiki_pages = %w[
   Cockpit-Coding-Guidelines
   Contributing
   Workflow
+  Proxying-Cockpit-over-NGINX
+  Proxying-Cockpit-over-Apache-with-LetsEncrypt
 ]
 
 # Pages to fetch from the Cockpit git repo


### PR DESCRIPTION
Adding two wiki pages to our externals, so they're on the website and indexed for easy searching.

- https://github.com/cockpit-project/cockpit/wiki/Proxying-Cockpit-over-NGINX
- https://github.com/cockpit-project/cockpit/wiki/Proxying-Cockpit-over-Apache-with-LetsEncrypt

Fixes #525