### PR TITLE
Add warning regarding removal of cockpit.css

### DIFF
--- a/_posts/2014-11-13-cockpit-plugin-tutorial.md
+++ b/_posts/2014-11-13-cockpit-plugin-tutorial.md
@@ -82,6 +82,9 @@ The pinger tool itself looks like this:
 
 Lets take a look at the pinger HTML, and see how it works.
 
+_**Warning**: Since Cockpit 273 ([relevant pull request](https://github.com/cockpit-project/cockpit/pull/17486)), `cockpit.css` can no longer be included as described below, since it was removed from Cockpit._
+{:.warning}
+
 ```html
 <!DOCTYPE html>
 <html>


### PR DESCRIPTION
I'm aware this post is known to be outdated and the starter kit should be used when getting into cockpit plugin development, but speaking from experience, this post is very enticing as a starting point (especially since going the route of [`cockpit-project.org > Contribute`](https://cockpit-project.org/external/wiki/Contributing.html)` > Further Reading > Create plugins for the user interface`, no mention of it being outdated is made). Anyone stumbling on to this page as a starting point will have some frustration saved by including a note here on cockpit.css being removed.