### PR TITLE
browser: Update :is() and :where() support test with values

### DIFF
--- a/_data/browser_support.yml
+++ b/_data/browser_support.yml
@@ -63,4 +63,4 @@ rules:
     - display
     - grid
   mdn-css_selectors_where:
-    css: selector(:is():where())
+    css: selector(:is(*):where(*))

--- a/_scripts/update-browser-data.rb
+++ b/_scripts/update-browser-data.rb
@@ -61,7 +61,7 @@ supports = YAML.safe_load("
         css: 'selector(test)'
 
     mdn-css_selectors_where:
-        css: 'selector(:is():where())'
+        css: 'selector(:is(*):where(*))'
 ")
 
 caniuse_db = 'https://raw.githubusercontent.com/Fyrd/caniuse/main/data.json'


### PR DESCRIPTION
Browsers are starting to support the next level of :is/:where.

Unfortunately, it seems our query string only targeted level 1.

Website counterpart to https://github.com/cockpit-project/cockpit/issues/17724 & https://github.com/cockpit-project/cockpit/pull/17726