### PR TITLE
Updating out of date info about cockpit/ws

### DIFF
--- a/running.md
+++ b/running.md
@@ -173,12 +173,12 @@ If you want to also run a web server to log in directly on the CoreOS host:
 
 4. Run the Cockpit web service with a privileged container (as root):
    ```
-   podman container runlabel --name cockpit-ws RUN docker.io/cockpit/ws
+   podman container runlabel --name cockpit-ws RUN quay.io/cockpit/ws
    ```
 
 5. Make Cockpit start on boot:
    ```
-   podman container runlabel INSTALL docker.io/cockpit/ws
+   podman container runlabel INSTALL quay.io/cockpit/ws
    systemctl enable cockpit.service
    ```
 


### PR DESCRIPTION
As far as I understood, the Docker Hub image was not updated in quite a long time and was superseded by the quay.io image. Making sure nobody installs out of date software with this update of the documentation.