### PR TITLE
Don't repeat Cockpit client link in blog post

### DIFF
--- a/_scripts/generate-release-notes.rb
+++ b/_scripts/generate-release-notes.rb
@@ -81,13 +81,13 @@ Here are the release notes from VERSIONS:
 VERSIONS ARE available now:
 
 * [For your Linux system](https://cockpit-project.org/running.html)
+* [Cockpit Client](https://flathub.org/apps/details/org.cockpit_project.CockpitClient)
 "
 
 @footer_dynamic = "
 * [NAME Source Tarball](https://github.com/cockpit-project/REPO/releases/tag/VERSIONS)
 * [NAME Fedora 37](https://bodhi.fedoraproject.org/updates/?releases=F37&packages=REPO)
 * [NAME Fedora 36](https://bodhi.fedoraproject.org/updates/?releases=F36&packages=REPO)
-* [Cockpit Client](https://flathub.org/apps/details/org.cockpit_project.CockpitClient)
 "
 
 ### Code below ###


### PR DESCRIPTION
generate-release-notes script had Cockpit client link in "footer_dynamic", which was added to footer in loop for each released repo. This caused that footer would contain multiple of the same "Cockpit client" links.

[Cockpit 279 release notes](https://cockpit-project.org/blog/cockpit-279.html) are example of this:
![Screenshot from 2022-12-02 12-27-27](https://user-images.githubusercontent.com/42733240/205282891-415165a1-ec6b-43b4-a778-be1b9d3a64b5.png)
