### PR TITLE
search: Fix unstable sorting in Chrome

### DIFF
--- a/assets/lib/search.coffee
+++ b/assets/lib/search.coffee
@@ -81,7 +81,7 @@ $ ->
         scoreB = pages[b].score = (titleB * 3 + summB + dateScoreB) / 5 / 0.71
 
         # Sort based on score
-        return scoreA < scoreB
+        return scoreB - scoreA
 
       for match in matches
         page = pages[match]


### PR DESCRIPTION
While `return scoreA < scoreB` works in Gecko and WebKit and _used to_ work in Blink, sorting "broke" (it still worked, but not as intended) in Chrome at some point.

Switching the less-than comparison to a minus makes all browser engines work the same (as Gecko, WebKit, and an older Blink engine does in either variant).

Preview is at https://garrett.github.io/cockpit-project.github.io/search.html#javascript