### PR TITLE
running, data: Promote Arch to "tested"

### DIFF
--- a/_data/distros.yml
+++ b/_data/distros.yml
@@ -23,6 +23,11 @@
   tested: true
   included: true
 
+- archlinux:
+  name: Arch Linux
+  tested: true
+  included: true
+
 - ubuntu:
   name: Ubuntu
   tested: true
@@ -30,10 +35,6 @@
 
 - clearlinux:
   name: Clear Linux
-  included: true
-
-- archlinux:
-  name: Arch Linux
   included: true
 
 - tumbleweed:

--- a/running.md
+++ b/running.md
@@ -243,16 +243,6 @@ sudo apt install -t ${VERSION_CODENAME}-backports cockpit
 {:.note}
 When updating Cockpit-related packages and any dependencies, make sure to use `-t ...-backports` as above, so backports are included.
 
-### Clear Linux
-{:#clearlinux}
-
-Cockpit is in [Clear Linux](https://clearlinux.org/) OS and can be installed using `swupd`:
-
-```
-sudo swupd bundle-add sysadmin-remote
-sudo systemctl enable --now cockpit.socket
-```
-
 
 ### Arch Linux
 {:#archlinux}
@@ -264,6 +254,17 @@ sudo systemctl enable --now cockpit.socket
 ```
 
 If the first command fails with "database file for ... does not exist", refresh/update your system with `sudo pacman -Syu` first.
+
+
+### Clear Linux
+{:#clearlinux}
+
+Cockpit is in [Clear Linux](https://clearlinux.org/) OS and can be installed using `swupd`:
+
+```
+sudo swupd bundle-add sysadmin-remote
+sudo systemctl enable --now cockpit.socket
+```
 
 
 ### openSUSE Tumbleweed


### PR DESCRIPTION
We test on Arch, so we should mention that on our running/install page.

I've added the tested flag and reordered the distros to keep all tested ones next to each other.