### PR TITLE
style: Add a default scroll margin

### DIFF
--- a/assets/site.scss
+++ b/assets/site.scss
@@ -147,6 +147,10 @@ body {
   display: none;
 }
 
+[id] {
+	scroll-margin-block-start: var(--scroll-margin, 2rem);
+}
+
 :where(h1, h2, h3, h4, h5, h6, blockquote, dl, ol, ul, figure, p, pre) {
   margin-block-end: .5em;
 }


### PR DESCRIPTION
This adds a little space above a fragment-linked item (foo.html#bar), for in-page linking.

I've added a --scroll-margin variable which can be used to customize it per page. But we rely on the fallback for now.