### PR TITLE
fix: add Raspberry Pi required step

### DIFF
--- a/faq.md
+++ b/faq.md
@@ -136,7 +136,13 @@ Create a placeholder file and network interface.
     nmcli con add type dummy con-name fake ifname fake0 ip4 1.2.3.4/24 gw4 1.2.3.1
     ```
 
-3. Reboot
+3. Skip this step unless you have a Raspberry Pi; install extra Linux kernel modules for networking:
+
+    ```
+    sudo apt install linux-modules-extra-raspi
+    ```
+
+4. Reboot
 
 ##### Explanation
 {:.no_toc}

--- a/faq.md
+++ b/faq.md
@@ -130,16 +130,16 @@ Create a placeholder file and network interface.
     unmanaged-devices=none
     ```
 
-2. Set up a "dummy" network interface:
-
-    ```
-    nmcli con add type dummy con-name fake ifname fake0 ip4 1.2.3.4/24 gw4 1.2.3.1
-    ```
-
-3. Skip this step unless you have a Raspberry Pi; install extra Linux kernel modules for networking:
+2. If you run on Ubuntu with arm64 (e.g.: on a Raspberry Pi), install extra Linux kernel modules for networking:
 
     ```
     sudo apt install linux-modules-extra-raspi
+    ```
+
+3. Set up a "dummy" network interface:
+
+    ```
+    nmcli con add type dummy con-name fake ifname fake0 ip4 1.2.3.4/24 gw4 1.2.3.1
     ```
 
 4. Reboot


### PR DESCRIPTION
https://github.com/cockpit-project/cockpit/issues/8477#issuecomment-1824633520 discovered a missing dependency that completes the solution in the FAQ.

Confirmed on my Raspberry Pi 4b with Ubuntu 22.04.3 LTS (jammy), so I'm improving the FAQ.