### PR TITLE
apps: Display title without trailing whitespace

### DIFF
--- a/_includes/apps.html
+++ b/_includes/apps.html
@@ -31,9 +31,7 @@
 {% assign link_url = app.homepage | default: app_source %}
 
 <article id="slug" class="app">
-  <h4 class="app-title">
-  {{ app.title }}
-  </h4>
+  <h4 class="app-title">{{ app.title }}</h4>
 
   <header class="app-tags">
     {% if app.official %}


### PR DESCRIPTION
There is a whitespace character trailing the app's title in the https://cockpit-project.org/applications.html page. This appears to be due to the `app-title` text containing additional newline and whitespace characters:
![image](https://github.com/cockpit-project/cockpit-project.github.io/assets/12111013/856b5cd3-067d-48c1-b5b4-b686212f1683)


I think this change should resolve the issue, though I am unable to test it due to #725.

I'm opening this PR in case the maintainers agree with the fix without requiring me to resolve the testing issue.