### PR TITLE
fix(running.md): broken archlinux web package link

### DIFF
--- a/running.md
+++ b/running.md
@@ -247,7 +247,7 @@ When updating Cockpit-related packages and any dependencies, make sure to use `-
 ### Arch Linux
 {:#archlinux}
 
-[Cockpit](https://www.archlinux.org/packages/community/x86_64/cockpit/) is available in [Arch Linux](https://www.archlinux.org/packages/):
+[Cockpit](https://archlinux.org/packages/extra/x86_64/cockpit/) is available in [Arch Linux](https://www.archlinux.org/packages/):
 ```
 sudo pacman -S cockpit
 sudo systemctl enable --now cockpit.socket


### PR DESCRIPTION
archlinux has merged extra and community, and now all community packages are in extra https://archlinux.org/news/git-migration-completed/