### PR TITLE
running: Fix SUSE commands

### DIFF
--- a/running.md
+++ b/running.md
@@ -267,7 +267,7 @@ sudo systemctl enable --now cockpit.socket
 ```
 
 
-### openSUSE Tumbleweed and Leap 
+### openSUSE Tumbleweed and Leap
 {:#tumbleweed}
 
 [Cockpit](https://software.opensuse.org/package/cockpit) is available in both [openSUSE Tumbleweed](https://get.opensuse.org/tumbleweed) and [openSUSE Leap](https://get.opensuse.org/leap) starting by 15.6:
@@ -275,20 +275,21 @@ sudo systemctl enable --now cockpit.socket
 
 1. Install cockpit:
 ```
-# zypper in cockpit
+zypper in cockpit
 ```
 2. Enable cockpit:
 ```
-# systemctl enable --now cockpit.socket
+systemctl enable --now cockpit.socket
 ```
 3. Open the firewall if necessary:
 ```
-# firewall-cmd --permanent --zone=public --add-service=cockpit
-# firewall-cmd --reload
+firewall-cmd --permanent --zone=public --add-service=cockpit
+firewall-cmd --reload
 ```
 4. Optionally allow root access (disabled by default)
 ```
-# sudo $EDITOR_OF_CHOICE /etc/cockpit/disallowed-users
+$EDITOR /etc/cockpit/disallowed-users
+```
 
 ### SUSE Linux Enterprise Micro
 {:#slemicro}


### PR DESCRIPTION
I happened to notice several problems with the SUSE section on the "running" page and made a commit to fix these:

1. The last SUSE command was lacking the ``` ending, so it was formatted incorrectly
2. All commands used `#`, which is a comment (in addition to the standard root prompt), so copy/pasting the full line wouldn't work
3. All instructions on the page are done via the root account already, so sudo isn't needed
4. `$EDITOR` actually is set by default and uses the default editor... the "of choice" is implied, as someone can change the editor to whatever they want; this makes it clear to use whatever editor _and_ allows a copy/paste to work