### PR TITLE
scripts: update Fedora releases

### DIFF
--- a/_scripts/generate-release-notes.rb
+++ b/_scripts/generate-release-notes.rb
@@ -88,8 +88,8 @@ VERSIONS ARE available now:
 
 @footer_dynamic = "
 * [NAME Source Tarball](https://github.com/cockpit-project/REPO/releases/tag/VERSIONS)
+* [NAME Fedora 41](https://bodhi.fedoraproject.org/updates/?releases=F41&packages=REPO)
 * [NAME Fedora 40](https://bodhi.fedoraproject.org/updates/?releases=F40&packages=REPO)
-* [NAME Fedora 39](https://bodhi.fedoraproject.org/updates/?releases=F39&packages=REPO)
 "
 
 ### Code below ###


### PR DESCRIPTION
Fedora-39 is no longer supported, Fedora-41 was released and we still release to Fedora-40.