### PR TITLE
scripts: Add custom livereload port, hopefully fixing WSL2

### DIFF
--- a/_scripts/container-jekyll
+++ b/_scripts/container-jekyll
@@ -1,3 +1,14 @@
 #!/bin/bash -e
 
-"$(dirname "$0")"/container-run bundle exec jekyll server -H 0.0.0.0 "$*"
+# We need to set host to 0.0.0.0 so anyone can connect, including other
+# devices (like phones) and VMs... and also Windows connecting to WSL2
+
+# Livereload is a port >5000 by default, which causes problems when
+# running on WSL2 in Windows, so let's set the port for everyone.
+
+# All other flags passed to the script will be sent to `jekyll server`,
+# including `--help`, which lists the available flags
+
+"$(dirname "$0")"/container-run bundle exec jekyll server \
+  --host 0.0.0.0 --livereload-port 4001 \
+  "$*"


### PR DESCRIPTION
This shouldn't affect Linux (aside from another port being used), and this port is not even used unless the script is called with a flag that enables livereload.

It has the benefit of making the livereload port closer to the server port too. (Although it does not really matter, outside of the port being <5000, which affects WSL2 apparently.)