### PR TITLE
Update running.md - Added commands to install for Linux Mint

### DIFF
--- a/running.md
+++ b/running.md
@@ -243,6 +243,15 @@ sudo apt install -t ${VERSION_CODENAME}-backports cockpit
 {:.note}
 When updating Cockpit-related packages and any dependencies, make sure to use `-t ...-backports` as above, so backports are included.
 
+### Linux Mint
+
+```
+. /etc/os-release
+sudo apt install -t ${UBUNTU_CODENAME}-backports cockpit
+```
+
+{:.note}
+When updating Cockpit-related packages and any dependencies, make sure to use `-t ...-backports` as above, so backports are included.
 
 ### Arch Linux
 {:#archlinux}


### PR DESCRIPTION
Added commands to install for Linux Mint.  Tested successfully on:

NAME="Linux Mint"
VERSION="22.1 (Xia)"
ID=linuxmint
ID_LIKE="ubuntu debian"
PRETTY_NAME="Linux Mint 22.1"
VERSION_ID="22.1"
VERSION_CODENAME=xia
UBUNTU_CODENAME=noble