### PR TITLE
Replace double quotes from title attribute with a single quote

### DIFF
--- a/index.md
+++ b/index.md
@@ -196,7 +196,8 @@ Contributing
 {% capture badge %}
 {% assign release = site.posts | where: "category", "release" | first %}
 {% assign version = release.title | split: "and" | first | split: " " | last %}
-<a href="{{ site.baseurl }}{{ release.url }}" title="{{ release.summary }}">
+{% assign summary = release.summary | replace: '"', "'" %}
+<a href="{{ site.baseurl }}{{ release.url }}" title="{{ summary }}">
   <span class="badge-new">
     Released
     <span class="badge-date">{{ release.date | date: "%-d %b %Y" }}</span>:


### PR DESCRIPTION
Jekyll isn't smart enough to escape or translate this so leaving double quote strings generates invalid html.