### PR TITLE
applications: Add separate maintainers file

### DIFF
--- a/_data/applications.yml
+++ b/_data/applications.yml
@@ -1,8 +1,9 @@
-# Entries on the page show up in the order listed here, but with
-# maintainer: cockpit (official) first
-# maintainer: redhat  (unofficial; non-team RH developed) second
-# maintainer: suse (unofficial; developed and maintained by suse)
-# maintainer: nil (third party) last
+# Entries here are displayed under their respective maintainer field.
+# If let unset it will be seen as third-party.
+# Available options are seen in maintainers.yml and for example be
+# - cockpit
+# - redhat
+# - suse
 
 # The Cockpit group is special, it inherits source, issues, license for the `source: cockpit` entries
 cockpit:

--- a/_data/maintainers.yml
+++ b/_data/maintainers.yml
@@ -1,0 +1,14 @@
+# Entries on the page show up in the order listed here
+# - cockpit (official) first
+# - redhat  (unofficial; non-team RH developed) second
+# - suse (unofficial; developed and maintained by suse)
+# - nil/not set (third party) last
+
+cockpit:
+  title: Cockpit
+
+redhat:
+  title: Red Hat
+
+suse:
+  title: SUSE

--- a/_includes/apps.html
+++ b/_includes/apps.html
@@ -4,9 +4,8 @@
 {% assign https = '>https://' %}
 {% assign gt = '>' %}
 
-{% for app_data in include.apps %}
-  {% assign slug = app_data | first %}
-  {% assign app = app_data | last %}
+{% for app in include.apps %}
+  {% assign slug = app.package %}
 
   {% comment %} Title is mandatory for output {% endcomment %}
   {% unless app.title %}{% continue %}{% endunless %}
@@ -14,23 +13,23 @@
   {% if app.source == 'cockpit'
     %}{% comment %}
     Graft in Cockpit's defaults
-    {% endcomment %}{% 
+    {% endcomment %}{%
     assign app_source = default.source
-    %}{% 
+    %}{%
     assign app_issues = default.issues
-    %}{% 
+    %}{%
     assign app_license = default.license
   %}{% else %}{%
     assign app_source = app.source
-    %}{% 
+    %}{%
     assign app_issues = app.issues
-    %}{% 
+    %}{%
     assign app_license = app.license
   %}{% endif %}
 
 {% assign link_url = app.homepage | default: app_source %}
 
-<article id="slug" class="app">
+<article id="{{slug}}" class="app">
   <h4 class="app-title">{{ app.title }}</h4>
 
   <header class="app-tags">

--- a/applications.md
+++ b/applications.md
@@ -15,20 +15,13 @@ Often, these applications are available to install with a click of a button on t
 Help us [expand this list](https://github.com/cockpit-project/cockpit-project.github.io/edit/main/_data/applications.yml)! Also consider [developing]({{ site.baseurl }}/external/wiki/Contributing.html) [your own application with the Starter Kit]({{ site.baseurl }}/blog/cockpit-starter-kit.html).
 
 {% assign apps = site.data.applications %}
-{% assign grouped = apps | group_by_exp: 'item', 'item[1].maintainer' %}
 
-### Official Cockpit-developed applications
-{% assign official = grouped[1].items %}
-{% include apps.html apps=official %}
-
-### Red Hat developed applications
-{% assign unofficial = grouped[2].items %}
-{% include apps.html apps=unofficial %}
-
-### SUSE developed applications
-{% assign suse_apps = grouped[3].items %}
-{% include apps.html apps=suse_apps %}
+{% for maintainer in site.data.maintainers %}
+### {{ maintainer[1].title }} developed applications
+{% assign maintainer_apps = apps | where: 'maintainer', maintainer[0] %}
+{% include apps.html apps=maintainer_apps %}
+{% endfor %}
 
 ### Third party
-{% assign thirdparty = grouped[0].items %}
+{% assign thirdparty = apps | where_exp: 'item', 'item.maintainer == nil' %}
 {% include apps.html apps=thirdparty %}


### PR DESCRIPTION
Should consolidate the maintainers file and make it a bit easier when it
comes to sorting and also not mess anything up when it comes to
third-party or new entries.

This also makes it easier to add new entries if we get other vendors
with many packages or noteworthy ones.

Signed-off-by: Freya Gustavsson <freya@venefilyn.se>
