### PR TITLE
css: Inherit color for variablelist

### DIFF
--- a/assets/site/guide.scss
+++ b/assets/site/guide.scss
@@ -35,6 +35,7 @@ html.cockpit-guide {
     div.part,
     div.variablelist table,
     pre.programlisting {
+      color: inherit;
       font-size: inherit;
       line-height: inherit;
     }
@@ -113,7 +114,7 @@ html.cockpit-guide {
     }
 
     @extend %link;
-  
+
     a {
       align-items: center;
       height: 100%;


### PR DESCRIPTION
We had components that got colors from components or something else than
our own code. This changes table, variablelist and others to inherit the
color from what we set higher up. Should fix dark mode issues

Fixes: #810
Signed-off-by: Freya Gustavsson <freya@venefilyn.se>
