### PR TITLE
Fix title to only mention Cockpit

### DIFF
--- a/_posts/2025-06-25-cockpit-341.md
+++ b/_posts/2025-06-25-cockpit-341.md
@@ -1,5 +1,5 @@
 ---
-title: Cockpit 341 and Cockpit-podman 108
+title: Cockpit 341
 author: jelle
 date: '2025-06-25'
 tags: cockpit


### PR DESCRIPTION
We usually only show Cockpit's version number.