### PR TITLE
_scripts: revert arg for generate release notes

### DIFF
--- a/_scripts/generate-release-notes
+++ b/_scripts/generate-release-notes
@@ -12,8 +12,6 @@ import json
 import os
 import re
 import sys
-import urllib
-import urllib.error
 from html.parser import HTMLParser
 from pathlib import Path
 from typing import Any
@@ -421,10 +419,10 @@ def main():
         help="Preview release notes with open PRs and more info",
     )
     parser.add_argument(
-        "-i",
-        "--increment",
+        "-r",
+        "--released",
         action="store_true",
-        help="Increment Cockpit version",
+        help="Cockpit has been released (do not increment version)",
     )
     # TODO: validate author
     parser.add_argument(
@@ -442,7 +440,7 @@ def main():
     args = parser.parse_args()
     user = args.user
 
-    increment = 1 if args.increment else 0
+    increment = 0 if args.released else 1
     final_notes = construct_all_the_notes(user, args.preview, increment, args.verbose)
     output_filename = Path("_posts") / markdown_filename()
     with open(output_filename, "w", encoding="utf-8") as f:


### PR DESCRIPTION
I had previously changed the `released` argument of generate release
notes script to function in reverse by renaming it to `increment`
instead.

My assumption had been that `released` was used when we didn't want to
update version for the blog post, and instead felt it would be easier to
have an `increment` argument instead.

This reverts it back to how it was before