### PR TITLE
Add Download Superstation to applications list

### DIFF
--- a/_data/applications.yml
+++ b/_data/applications.yml
@@ -335,3 +335,16 @@ pacman:
   license: GPL-3.0
   description: |
     Arch Linux package management using direct alpm.rs integration.
+
+download-superstation:
+  title: Download Superstation
+  package: cockpit-download-superstation
+  source: https://github.com/dl-romero/cockpit-download-superstation
+  issues: https://github.com/dl-romero/cockpit-download-superstation/issues
+  license: MIT
+  prerelease: false
+  description: |
+    Torrent management backed by libtorrent. Add torrents via .torrent file or
+    magnet link, set per-torrent and per-file download priorities, and monitor
+    speeds, peers, and trackers in real time. Includes one-click Start/Stop for
+    the Download Superstation systemd service.


### PR DESCRIPTION
## Summary

This PR adds [Download Superstation](https://github.com/dl-romero/cockpit-download-superstation) to the Cockpit applications listing.

- **Repository:** https://github.com/dl-romero/cockpit-download-superstation
- **Package:** `cockpit-download-superstation`
- **License:** MIT
- **Issues:** https://github.com/dl-romero/cockpit-download-superstation/issues

## About

Download Superstation is a self-hosted torrent manager backed by libtorrent ([main service repo](https://github.com/dl-romero/download-superstation)). The Cockpit plugin provides full torrent management directly in the Cockpit UI:

- Add torrents via `.torrent` file (drag & drop) or magnet link
- Per-torrent and per-file download priorities
- Live progress, speeds, peers, and trackers
- Sidebar categories: All, Downloading, Seeding, Finished, Paused, Error
- Real-time systemd service status with one-click Start/Stop
- Settings — download path, speed limits, seeding limits, password change

The plugin communicates with the service via `cockpit.http()` (bridge proxy), so no extra firewall ports or CORS configuration is required. It auto-discovers whichever service unit is in use (`download-superstation` for Docker/Podman installs, `torrent-webui` for legacy bare-metal installs) and only appears in the menu when one of those units is present on the host.