### PR TITLE
Add cockpit-nspawn: systemd-nspawn container management

### DIFF
--- a/_data/applications.yml
+++ b/_data/applications.yml
@@ -348,3 +348,14 @@ download-superstation:
     magnet link, set per-torrent and per-file download priorities, and monitor
     speeds, peers, and trackers in real time. Includes one-click Start/Stop for
     the Download Superstation systemd service.
+
+nspawn:
+  title: Systemd-nspawn Containers
+  package: cockpit-nspawn
+  source: https://github.com/realmcuser/cockpit-nspawn
+  issues: https://github.com/realmcuser/cockpit-nspawn/issues
+  license: LGPL 2.1
+  description: |
+    Manage systemd-nspawn containers. Create, start, stop, and back up
+    lightweight system containers with full systemd support — directly
+    from Cockpit. No Docker required.


### PR DESCRIPTION
Adds cockpit-nspawn to the third-party applications list.

cockpit-nspawn is a Cockpit module for managing systemd-nspawn containers — create, start, stop, and back up lightweight system containers with full systemd support, directly from the Cockpit web console.

- GitHub: https://github.com/realmcuser/cockpit-nspawn
- License: LGPL 2.1
- RPM packages available for Fedora 43/44, AlmaLinux 9/10