### PR TITLE
Add Docker Compose application information

### DIFF
--- a/_data/applications.yml
+++ b/_data/applications.yml
@@ -359,3 +359,14 @@ nspawn:
     Manage systemd-nspawn containers. Create, start, stop, and back up
     lightweight system containers with full systemd support — directly
     from Cockpit. No Docker required.
+
+docker-compose:
+  title: Docker Compose
+  package: cockpit-compose
+  prerelease: true
+  source: https://github.com/RXTX4816/cockpit-compose
+  issues: https://github.com/RXTX4816/cockpit-compose/issues
+  license: MIT
+  description: |
+    Dashboard to manage Docker Compose stacks with live status view.
+    See logs, edit and restore Compose yaml files and more to come.

--- a/_data/applications.yml
+++ b/_data/applications.yml
@@ -348,3 +348,14 @@ download-superstation:
     magnet link, set per-torrent and per-file download priorities, and monitor
     speeds, peers, and trackers in real time. Includes one-click Start/Stop for
     the Download Superstation systemd service.
+
+docker-compose:
+  title: Docker Compose
+  package: cockpit-compose
+  prerelease: true
+  source: https://github.com/RXTX4816/cockpit-compose
+  issues: https://github.com/RXTX4816/cockpit-compose/issues
+  license: MIT
+  description: |
+    Dashboard to manage Docker Compose stacks with live status view.
+    See logs, edit and restore Compose yaml files and more to come.


### PR DESCRIPTION
This PR adds [cockpit-compose](https://github.com/RXTX4816/cockpit-compose) to the Cockpit 3rd party applications listing.

- **Repository:** https://github.com/RXTX4816/cockpit-compose
- **Package:** `cockpit-compose`
- **License:** MIT
- **Issues:** https://github.com/RXTX4816/cockpit-compose/issues

Cockpit-compose enables Docker Compose management directly from the Cockpit WebUI.

- Dashboard listing all stacks with live status and container stats
- Start / stop / restart stacks with one click
- Live log viewer per container
- YAML editor with syntax validation and auto-snapshot before saving
- Snapshot restore — roll back a compose file to any previous version

The plugin communicates with Docker entirely through cockpit.spawn() (the Cockpit bridge), so no extra ports, HTTP APIs, or CORS configuration are needed. It auto-detects whichever Compose binary is present — the docker compose v2 plugin or the legacy docker-compose standalone — and falls back gracefully. File operations (reading and writing compose files and snapshots) use cockpit.file() through the same bridge, with superuser: "try" for operations that require elevated permissions.