### PR TITLE
Add cockpit-scap — SCAP compliance scanning and remediation for RHEL 10

### DIFF
--- a/_data/applications.yml
+++ b/_data/applications.yml
@@ -370,3 +370,15 @@ docker-compose:
   description: |
     Dashboard to manage Docker Compose stacks with live status view.
     See logs, edit and restore Compose yaml files and more to come.
+
+scap:
+  title: SCAP Compliance
+  package: cockpit-scap
+  source: https://github.com/pbuchan-rh/cockpit-scap
+  issues: https://github.com/pbuchan-rh/cockpit-scap/issues
+  license: LGPL 2.1
+  description: |
+    OpenSCAP compliance scanning, profile tailoring, and selective remediation
+    for RHEL 10 and CentOS Stream 10. Scan hosts and container images against
+    SCAP Security Guide profiles, tailor rules to your environment, and download
+    or apply remediation scripts — directly from the Cockpit browser console.


### PR DESCRIPTION
## What is cockpit-scap?

A native Cockpit module that brings OpenSCAP compliance scanning, profile tailoring, container image scanning, and selective remediation into the Cockpit browser console for RHEL 10 and CentOS Stream 10.

**Source:** https://github.com/pbuchan-rh/cockpit-scap  
**License:** LGPL 2.1  
**Package:** `cockpit-scap` (available via [Fedora COPR](https://copr.fedorainfracloud.org/coprs/pbuchan-rh/cockpit-scap/))

## Capabilities

- Host and container image scanning against SCAP Security Guide profiles
- Failing rules with CCE identifiers, inline description/rationale, and Automated/Manual annotation
- Selective remediation builder — pick rules, download bash/Ansible/Puppet scripts, or Apply Now with two-gate confirmation and live output
- XCCDF profile tailoring editor with saved policies and per-policy compliance thresholds
- Activity log with systemd journal integration
- SELinux enforcing mode support; CIS L2 hardening compatible

## Installation

```bash
dnf copr enable pbuchan-rh/cockpit-scap
dnf install cockpit-scap
```