### PR TITLE
PRs: Add preview workflow using surge

### DIFF
--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -1,0 +1,42 @@
+name: Surge PR Preview - Build Stage
+
+on:
+  pull_request:
+
+env:
+  REPO_OWNER: "${{ github.repository_owner }}"
+  REPO_NAME: "${{ github.event.repository.name }}"
+  PR_NUMBER: "${{ github.event.pull_request.number }}"
+  PAGES_REPO_NWO: "${{ github.repository_owner }}/${{ github.event.repository.name }}"
+
+jobs:
+  build-preview:
+    runs-on: ubuntu-24.04
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.3' # Not needed with a .ruby-version file
+          bundler-cache: true # runs 'bundle install' and caches installed gems automatically
+          cache-version: 0 # Increment this number if you need to re-download cached gems
+
+      - name: Get repo name
+        id: clean-repo-name
+        run: |
+          echo "repo_name=${REPO_NAME//./-}" >> $GITHUB_OUTPUT
+
+      - name: Build with Jekyll
+        env:
+          JEKYLL_ENV: production
+        # Outputs to the './_site' directory by default
+        run: bundle exec jekyll build --baseurl "https://${{ env.REPO_OWNER}}-${{ steps.clean-repo-name.outputs.repo_name }}-deploy-pr-${{ env.PR_NUMBER }}.surge.sh"
+
+      - name: Upload site artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: pr-build-dist
+          path: _site/

--- a/.github/workflows/pr-deployment.yml
+++ b/.github/workflows/pr-deployment.yml
@@ -1,0 +1,37 @@
+name: Surge PR Preview - Deploy Stage
+
+on:
+  workflow_run:
+    workflows: ["Surge PR Preview - Build Stage"]
+    types:
+      - completed
+
+permissions:
+  pull-requests: write # Needed to comment on PRs
+
+jobs:
+  # Important - the job id:
+  # MUST be unique across all surge preview deployments for a repository as the job id is used in the deployment URL
+  # MUST be kept in sync with the job id of the teardown stage (this id is used by the surge-preview action to forge the deployment URL)
+  deploy:
+    runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion == 'success' }}
+
+    steps:
+      - name: Download built site
+        uses: dawidd6/action-download-artifact@v21
+        with:
+          workflow: ${{ github.event.workflow_run.workflow_id }}
+          run_id: ${{ github.event.workflow_run.id }}
+          name: pr-build-dist  # Must match the name from build workflow
+          path: _site/
+
+      - name: Deploy to Surge
+        uses: afc163/surge-preview@v1
+        with:
+          surge_token: ${{ secrets.SURGE_TOKEN }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          build: echo done
+          dist: _site
+          failOnError: true
+          teardown: false # Teardown is handled by the separate workflow

--- a/.github/workflows/pr-teardown.yml
+++ b/.github/workflows/pr-teardown.yml
@@ -1,0 +1,21 @@
+name: Surge PR Preview - Teardown Stage
+
+on:
+  pull_request_target:
+    types: [closed]
+
+permissions:
+  pull-requests: write # Needed to comment on PRs
+
+jobs:
+  deploy: # Must match the job ID from the deploy workflow
+    runs-on: ubuntu-latest
+    steps:
+      - name: Teardown preview site
+        uses: afc163/surge-preview@v1
+        with:
+          surge_token: ${{ secrets.SURGE_TOKEN }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          failOnError: true
+          teardown: true
+          build: echo "Cleaning up preview" 

--- a/_config.yml
+++ b/_config.yml
@@ -74,6 +74,7 @@ exclude:
   - README.md
   - bin
   - LICENSE
+  - vendor/bundle
 
 include:
   - _stylesheets


### PR DESCRIPTION
Adds a PR preview workflows that
- Create a build from PR itself without secrets
- Publishes build artifact to surge.sh
- Tears down surge preview on PR closure

Reason for a split between build and publish has to do with a workaround
for security where workflows that are triggered on a pull request cannot
access secrets. As the deploy workflow just publishes an artifact it can
have access to secrets. Note this only has to do with PRs from forks and
does not matter for PRs within the repo itself.

We still need to explicitly approve workflows to run on outside
contributors.

Before merging this a surge token needs to be added to secrets as `SURGE_TOKEN`.
Ask me for token to add and I'll send it as I can't access the env or secrets in this repo

Signed-off-by: Freya Gustavsson <freya@venefilyn.se>
