### PR TITLE
_posts: fix typos in 2025 API post

### DIFF
--- a/_posts/2015-07-10-rest-api-plugin.md
+++ b/_posts/2015-07-10-rest-api-plugin.md
@@ -17,7 +17,7 @@ For this tutorial you'll need at least Cockpit 0.58. There was one last tweak th
 
 Here we'll make a package called *docker-info* which shows info about the docker daemon. We use the `/info` [docker API](https://docs.docker.com/reference/api/docker_remote_api_v1.18/#display-system-wide-information) to retrieve that info.
 
-I've prepared the [docker-info package here](https://cockpit-project.org/files/docker-info.tgz). It's just two files. To download them and extract to your current directory, and installs it as a Cockpit package:
+I've prepared the [docker-info package here](https://cockpit-project.org/files/docker-info.tgz). It's just two files. To download them and extract to your current directory, and install it as a Cockpit package:
 
 ```text
 $ wget https://cockpit-project.org/files/docker-info.tgz -O - | tar -xzf -
@@ -45,7 +45,7 @@ After a moment, you should see numbers pop up with some stats about the docker d
 $ sudo docker run -ti fedora /bin/bash
 ```
 
-You should see the numbers update as the container is pulled and started. When you type ```exit``` in the container, you should see the numbers update again. How is this happening? Lets take a look at the `docker-info` HTML:
+You should see the numbers update as the container is pulled and started. When you type ```exit``` in the container, you should see the numbers update again. How is this happening? Let's take a look at the `docker-info` HTML:
 
 ```html
 <head>
@@ -111,9 +111,9 @@ First we include `jquery.js` and `cockpit.js`. `cockpit.js` defines the basic AP
 <script src="../base1/cockpit.js"></script>
 ```
 
-We also include the cockpit.css file to make sure the look of our tool matches that of Cockpit. The HTML is pretty basic, defining a little list where the info shown.
+We also include the cockpit.css file to make sure the look of our tool matches that of Cockpit. The HTML is pretty basic, defining a little list where the info is shown.
 
-In the javascript code, first we setup an HTTP client to access docker. Docker listens for HTTP requests on a Unix socket called `/var/run/docker.sock`. In addition the permissions on that socket often require escalated privileges to access, so we tell Cockpit to try to gain `superuser` privileges for this task, but continue anyway if it cannot:
+In the javascript code, first we set up an HTTP client to access docker. Docker listens for HTTP requests on a Unix socket called `/var/run/docker.sock`. In addition the permissions on that socket often require escalated privileges to access, so we tell Cockpit to try to gain `superuser` privileges for this task, but continue anyway if it cannot:
 
 ```javascript
 var docker = cockpit.http("/var/run/docker.sock", { superuser: "try" });
@@ -121,7 +121,7 @@ var docker = cockpit.http("/var/run/docker.sock", { superuser: "try" });
 
 First we define how to retrieve info from Docker. We use the REST `/info` API to do this.
 
-```javascipt
+```javascript
 function retrieve_info() {
     var info = docker.get("/info");
     info.done(process_info);
@@ -157,7 +157,7 @@ Because we want to react to changes in Docker state, we also start a long reques
 var events = docker.get("/events");
 ```
 
-The `.get("/events")` call returns a jQuery Promise. When a line of event data arrives, the `.stream()` callback in invoked, and we use it to trigger a reload of the Docker info.
+The `.get("/events")` call returns a jQuery Promise. When a line of event data arrives, the `.stream()` callback is invoked, and we use it to trigger a reload of the Docker info.
 
 ```javascript
 events.stream(got_event);

--- a/external/wiki/Proxying-Cockpit-over-NGINX.md
+++ b/external/wiki/Proxying-Cockpit-over-NGINX.md
@@ -25,7 +25,7 @@ Origins = https://cockpit.domain.tld wss://cockpit.domain.tld
 ProtocolHeader = X-Forwarded-Proto
 ```
 
-These changes will let Cockpit know that connections will come through for https (secure http) and wss (secure websockets) on the subdomain cockpit.domain.tld, and that it should look for the `X-Forwarded-Proto` header to determine if the connection is secure or not. This is important as Cockpit will [redirect any non-local connection from http to https automatically]({{ site.baseurl }}/guide/149/https.html) and sees cockpit.domain.tld is non-local.
+These changes will let Cockpit know that connections will come through for https (secure http) and wss (secure websockets) on the subdomain cockpit.domain.tld, and that it should look for the `X-Forwarded-Proto` header to determine if the connection is secure or not, this is important as Cockpit will [redirect any non-local connection from http to https automatically]({{ site.baseurl }}/guide/149/https.html) and sees cockpit.domain.tld is non-local.
 
 Once these changes are made you will need to restart cockpit.
 
@@ -72,7 +72,7 @@ It is recommended you generate a valid, signed certificate for your server, you 
 
 Alternatively if you don't require a valid certificate you can [generate your own certificate](https://www.digitalocean.com/community/tutorials/openssl-essentials-working-with-ssl-certificates-private-keys-and-csrs#generating-ssl-certificates). This approach is only recommended for testing as you will get browser security warnings notifying you the connection is not secure.
 
-If all else fails you can use cockpit's self signed certificates which are stored in `/etc/cockpit/ws-certs.d/`. To do this you will need to split the `0-self-signed.cert` into two files, one containing the key and one containing the certificate.
+If all else fails you can use cockpits self signed certificates which are stored in `/etc/cockpit/ws-certs.d/`. To do this you will need to split the `0-self-signed.cert` into two files, one containing the key and one containing the certificate.
 
 ### 502 Bad Gateway & SELinux 
 If SELinux is enabled, change boolean setting (solves 502 gateway error):
@@ -90,7 +90,7 @@ You may want to serve cockpit from a subdirectory rather than a subdomain.
 
 For this example we will assume:
 * Cockpit is listening on port 9090
-* Nginx is listening on port 80 (http) and port 443 (https)
+* Nginx is listening on on port 80 (http) and port 443 (https)
 * You have a domain of domain.tld pointed to your nginx instance
 * You can access your nginx instance by connecting to http://domain.tld, even if you just get the default page
 * You want to access Cockpit via http://domain.tld/secret/
@@ -126,7 +126,7 @@ If you're not running nginx locally alongside Cockpit you will need to adjust th
 
 For this example we will assume:
 * Cockpit is listening on port 9090 on system 192.168.10.15
-* Nginx is listening on port 80 (http) and port 443 (https) on system 192.168.10.29
+* Nginx is listening on on port 80 (http) and port 443 (https) on system 192.168.10.29
 * You have a domain of domain.tld pointed to your nginx instance
 * You can access your nginx instance by connecting to http://domain.tld, even if you just get the default page
 

--- a/external/wiki/Proxying-Cockpit-over-NGINX.md
+++ b/external/wiki/Proxying-Cockpit-over-NGINX.md
@@ -25,7 +25,7 @@ Origins = https://cockpit.domain.tld wss://cockpit.domain.tld
 ProtocolHeader = X-Forwarded-Proto
 ```
 
-These changes will let Cockpit know that connections will come through for https (secure http) and wss (secure websockets) on the subdomain cockpit.domain.tld, and that it should look for the `X-Forwarded-Proto` header to determine if the connection is secure or not, this is important as Cockpit will [redirect any non-local connection from http to https automatically]({{ site.baseurl }}/guide/149/https.html) and sees cockpit.domain.tld is non-local.
+These changes will let Cockpit know that connections will come through for https (secure http) and wss (secure websockets) on the subdomain cockpit.domain.tld, and that it should look for the `X-Forwarded-Proto` header to determine if the connection is secure or not. This is important as Cockpit will [redirect any non-local connection from http to https automatically]({{ site.baseurl }}/guide/149/https.html) and sees cockpit.domain.tld is non-local.
 
 Once these changes are made you will need to restart cockpit.
 
@@ -72,7 +72,7 @@ It is recommended you generate a valid, signed certificate for your server, you 
 
 Alternatively if you don't require a valid certificate you can [generate your own certificate](https://www.digitalocean.com/community/tutorials/openssl-essentials-working-with-ssl-certificates-private-keys-and-csrs#generating-ssl-certificates). This approach is only recommended for testing as you will get browser security warnings notifying you the connection is not secure.
 
-If all else fails you can use cockpits self signed certificates which are stored in `/etc/cockpit/ws-certs.d/`. To do this you will need to split the `0-self-signed.cert` into two files, one containing the key and one containing the certificate.
+If all else fails you can use cockpit's self signed certificates which are stored in `/etc/cockpit/ws-certs.d/`. To do this you will need to split the `0-self-signed.cert` into two files, one containing the key and one containing the certificate.
 
 ### 502 Bad Gateway & SELinux 
 If SELinux is enabled, change boolean setting (solves 502 gateway error):
@@ -90,7 +90,7 @@ You may want to serve cockpit from a subdirectory rather than a subdomain.
 
 For this example we will assume:
 * Cockpit is listening on port 9090
-* Nginx is listening on on port 80 (http) and port 443 (https)
+* Nginx is listening on port 80 (http) and port 443 (https)
 * You have a domain of domain.tld pointed to your nginx instance
 * You can access your nginx instance by connecting to http://domain.tld, even if you just get the default page
 * You want to access Cockpit via http://domain.tld/secret/
@@ -126,7 +126,7 @@ If you're not running nginx locally alongside Cockpit you will need to adjust th
 
 For this example we will assume:
 * Cockpit is listening on port 9090 on system 192.168.10.15
-* Nginx is listening on on port 80 (http) and port 443 (https) on system 192.168.10.29
+* Nginx is listening on port 80 (http) and port 443 (https) on system 192.168.10.29
 * You have a domain of domain.tld pointed to your nginx instance
 * You can access your nginx instance by connecting to http://domain.tld, even if you just get the default page
 


### PR DESCRIPTION
## Summary

Fix 6 typos and grammar issues in 1 file:

- `_posts/2015-07-10-rest-api-plugin.md`: installs → install (verb parallelism), javascipt → javascript (code fence language tag), Lets → Let's, setup → set up (verb form), "where the info shown" → "where the info is shown" (missing word), "callback in invoked" → "callback is invoked"

6 additional findings in `guide/195/*.html` files were dropped because those files are auto-generated by DocBook XSL Stylesheets (per their `<meta name="generator">` tag) and fixes would be overwritten on regeneration.

No functional changes — documentation only.