### PR TITLE
PRs: Add preview workflow using GitHub Actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,70 @@
+name: Build Cockpit site
+
+on:
+  push:
+    branches:
+      - 'main'
+  pull_request:
+
+# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
+# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+env:
+  REPO_OWNER: "${{ github.repository_owner }}"
+  REPO_NAME: "${{ github.event.repository.name }}"
+  PR_NUMBER: "${{ github.event.pull_request.number }}"
+  PAGES_REPO_NWO: "${{ github.repository_owner }}/${{ github.event.repository.name }}"
+  PREVIEW_DIR: "preview-pr"
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.3' # Not needed with a .ruby-version file
+          bundler-cache: true # runs 'bundle install' and caches installed gems automatically
+          cache-version: 0 # Increment this number if you need to re-download cached gems
+
+      - name: Get repo name
+        id: clean-repo-name
+        run: |
+          echo "repo_name=${REPO_NAME//./-}" >> $GITHUB_OUTPUT
+
+      - name: Get base URL
+        id: url
+        run: |
+          if [[ ${{ env.REPO_OWNER }} == "cockpit-project" ]]
+          then
+            echo "domain_name=''" >> $GITHUB_OUTPUT
+          else
+            echo "domain_name=${{ env.REPO_NAME }}" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Build with Jekyll
+        if: ${{ github.event_name != 'pull_request' }}
+        env:
+          JEKYLL_ENV: production
+        # Outputs to the './_site' directory by default
+        run: bundle exec jekyll build --baseurl "${{ steps.url.outputs.domain_name }}"
+
+      - name: Build PR Preview with Jekyll
+        if: ${{ github.event_name == 'pull_request' }}
+        env:
+          JEKYLL_ENV: production
+        # Outputs to the './_site' directory by default
+        run: bundle exec jekyll build --baseurl "${{ steps.url.outputs.domain_name }}/${{ env.PREVIEW_DIR }}/${{ env.PR_NUMBER }}"
+
+      - name: Upload site artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: build-dist
+          path: _site/

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,114 @@
+name: Deploy Cockpit site
+
+on:
+  workflow_run:
+    workflows: ["Build Cockpit site"]
+    types:
+      - completed
+
+# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
+# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+permissions:
+  pull-requests: write # Needed to comment on PRs
+  contents: write # Needed for committing
+
+env:
+  REPO_OWNER: "${{ github.repository_owner }}"
+  REPO_NAME: "${{ github.event.repository.name }}"
+  PREVIEW_DIR: "preview-pr"
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.event != 'pull_request' && github.event.workflow_run.conclusion == 'success' }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Download built site
+        uses: dawidd6/action-download-artifact@v21
+        with:
+          workflow: ${{ github.event.workflow_run.workflow_id }}
+          run_id: ${{ github.event.workflow_run.id }}
+          name: build-dist  # Must match the name from build workflow
+          path: _site/
+
+      - name: Deploy 🚀
+        uses: JamesIves/github-pages-deploy-action@v4
+        with:
+          folder: _site/ # The folder the action should deploy.
+          clean: true
+          clean-exclude: |
+            ${{ env.PREVIEW_DIR }}
+          git-config-name: "github-actions[bot]"
+          git-config-email: 41898282+github-actions[bot]@users.noreply.github.com
+
+  deploy-pr:
+    runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion == 'success' }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Find associated pull request
+        id: pr
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const response = await github.rest.search.issuesAndPullRequests({
+              q: 'repo:${{ github.repository }} is:pr is:open sha:${{ github.event.workflow_run.head_sha }}',
+              per_page: 1,
+            })
+            const items = response.data.items
+            if (items.length < 1) {
+              console.error('No PRs found')
+              return
+            }
+            const pullRequestNumber = items[0].number
+            console.info("Pull request number is", pullRequestNumber)
+            return pullRequestNumber
+
+      - name: Get PR directory
+        id: pr_dir
+        run: |
+          echo "pr_dir=${{ env.PREVIEW_DIR }}/${{ steps.pr.outputs.result }}" >> $GITHUB_OUTPUT
+
+      - name: Download built site
+        uses: dawidd6/action-download-artifact@v21
+        with:
+          workflow: ${{ github.event.workflow_run.workflow_id }}
+          run_id: ${{ github.event.workflow_run.id }}
+          name: build-dist  # Must match the name from build workflow
+          path: _site/
+
+      - name: Get domain name
+        id: domain
+        run: |
+          if [[ ${{ env.REPO_OWNER }} == "cockpit-project" ]]
+          then
+            echo "domain_name=$(cat CNAME)" >> $GITHUB_OUTPUT
+          else
+            echo "domain_name=${{ env.REPO_OWNER }}.github.io/${{ env.REPO_NAME }}" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Deploy 🚀
+        uses: JamesIves/github-pages-deploy-action@v4
+        with:
+          folder: _site/ # The folder the action should deploy.
+          target-folder: ${{ steps.pr_dir.outputs.pr_dir }}
+          clean: true
+          git-config-name: "github-actions[bot]"
+          git-config-email: 41898282+github-actions[bot]@users.noreply.github.com
+          commit-message: "Deploying from PR #${{ steps.pr.outputs.result }} @ ${{ github.event.workflow_run.repository.full_name }}@${{ github.event.workflow_run.head_sha }}"
+
+      - name: Leave a comment after deployment for PRs
+        uses: marocchino/sticky-pull-request-comment@v3
+        with:
+            number: ${{ steps.pr.outputs.result }}
+            header: preview-pr
+            message: |
+              Preview available at <https://${{ steps.domain.outputs.domain_name }}/${{ steps.pr_dir.outputs.pr_dir }}>

--- a/.github/workflows/pr-teardown.yml
+++ b/.github/workflows/pr-teardown.yml
@@ -1,0 +1,51 @@
+name: Teardown PR preview
+
+on:
+  pull_request_target:
+    types: [closed]
+
+# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
+# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+permissions:
+  pull-requests: write # Needed to comment on PRs
+  contents: write # Needed for committing
+
+env:
+  PR_NUMBER: "${{ github.event.pull_request.number }}"
+  PREVIEW_DIR: "preview-pr"
+
+jobs:
+  pr-closed:
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          ref: gh-pages
+
+      - name: Setup git defaults
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Remove PR folder
+        run: |
+          rm -rf ${{ env.PREVIEW_DIR }}/${{ env.PR_NUMBER }}
+
+      - name: Teardown preview site
+        run: |
+          git add .
+          git commit -m "PR: Remove preview of #${{ env.PR_NUMBER }}"
+          git push
+
+      - name: Update PR comment
+        uses: marocchino/sticky-pull-request-comment@v3
+        with:
+            header: preview-pr
+            message: |
+              Preview removed as PR is merged or closed.


### PR DESCRIPTION
Adds a PR preview workflows that
- Create a build from PR itself without secrets
- Publishes build artifact to preview PR subdirectory in gh-pages branch
- Removes preview PR subdirectory from gh-pages branch

Reason for a split between build and publish has to do with a workaround
for security where workflows that are triggered on a pull request cannot
access secrets. As the deploy workflow just publishes an artifact it can
have access to secrets. Note this only has to do with PRs from forks and
does not matter for PRs within the repo itself.

PR deployment and PR teardowns are run from the base repository and is
therefore secure.

Build workflows will need to be manually approved from outside
contributors. They will only be deployed if build workflow has
succeeded.

Upon PR preview being created a comment will be added to the PR itself
with a link to the preview URL. If this PR is run against our main we
will publish the preview under <cockpit-project.org/preview-pr/> and if
the PR is run against a fork it will publish the preview under
<username.github.io/cockpit-project.github.io/preview-pr/>. If the user
has a custom domain for their <username.github.io> the links will still
work but just be redirected by GitHub.